### PR TITLE
feat: initial release v0.1.0 — whisper-ptt push-to-talk dictation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,60 @@
-# linux-push-to-talk
-Push-to-talk dictation para Linux usando OpenAI Whisper offline. Mantén presionada una tecla para grabar tu voz y el texto se escribe automáticamente donde tengas el cursor. Sin internet, sin APIs, funciona en cualquier aplicación. Compatible con X11, KDE, GNOME y XFCE.
+# whisper-ptt
+
+Push-to-talk dictation para Linux usando OpenAI Whisper offline.
+Mantén presionada una tecla para grabar tu voz y el texto se escribe
+automáticamente donde tengas el cursor. Sin internet, sin APIs, funciona
+en cualquier aplicación.
+
+## Características
+- 100% offline — tu voz nunca sale de tu máquina
+- Funciona en cualquier aplicación (navegador, editor, terminal, etc.)
+- Notificaciones visuales en KDE
+- Arranque automático al iniciar sesión (systemd)
+- Tecla configurable (por defecto F12)
+- Soporte multiidioma (español, inglés y más)
+
+## Requisitos
+- Linux con X11
+- Python 3.9+
+- xdotool y portaudio19-dev
+
+## Instalación
+```bash
+bash install.sh
+```
+
+## Uso
+| Acción | Resultado |
+|--------|-----------|
+| Mantener F12 | Inicia grabación |
+| Soltar F12 | Transcribe y escribe el texto |
+
+### Opciones avanzadas
+```bash
+dictate --key F10          # Cambiar tecla
+dictate --model medium     # Más preciso (más lento)
+dictate --language auto    # Detectar idioma automáticamente
+dictate --toggle           # Modo toggle en vez de mantener presionado
+```
+
+### Controlar el servicio
+```bash
+systemctl --user status whisper-dictation
+systemctl --user restart whisper-dictation
+systemctl --user stop whisper-dictation
+journalctl --user -u whisper-dictation -f
+```
+
+## Modelos disponibles
+| Modelo | Velocidad | Precisión | RAM aprox |
+|--------|-----------|-----------|-----------|
+| tiny   | Muy rápido | Básica   | 200 MB    |
+| base   | Rápido     | Buena    | 300 MB    |
+| small  | Medio      | Muy buena| 500 MB    |
+| medium | Lento      | Excelente| 1.5 GB    |
+
+## Probado en
+- Debian 12 (Bookworm) + KDE Plasma + X11
+
+## Licencia
+MIT

--- a/dictate
+++ b/dictate
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+exec ~/.local/share/whisper-dictation/bin/python3 ~/.local/bin/whisper-dictation.py "$@"

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+set -e
+
+# ── Colores ──────────────────────────────────────────────────────────────────
+RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'; NC='\033[0m'
+info()    { echo -e "${GREEN}[✓]${NC} $1"; }
+warn()    { echo -e "${YELLOW}[!]${NC} $1"; }
+error()   { echo -e "${RED}[✗]${NC} $1"; exit 1; }
+
+# ── Verificar que no se ejecute como root ─────────────────────────────────────
+[ "$EUID" -eq 0 ] && error "No ejecutar como root. Ejecuta como tu usuario normal."
+
+echo ""
+echo "  whisper-ptt — Instalador"
+echo "  Push-to-talk dictation con Whisper offline"
+echo ""
+
+# ── Dependencias del sistema ──────────────────────────────────────────────────
+info "Verificando dependencias del sistema..."
+MISSING=()
+command -v python3 &>/dev/null || MISSING+=("python3")
+command -v xdotool &>/dev/null || MISSING+=("xdotool")
+dpkg -l libportaudio2 &>/dev/null 2>&1 || MISSING+=("libportaudio2")
+
+if [ ${#MISSING[@]} -gt 0 ]; then
+    warn "Instalando dependencias faltantes: ${MISSING[*]}"
+    sudo apt-get install -y "${MISSING[@]}" portaudio19-dev
+fi
+
+# ── Entorno virtual Python ────────────────────────────────────────────────────
+VENV_DIR="$HOME/.local/share/whisper-dictation"
+info "Creando entorno virtual en $VENV_DIR..."
+python3 -m venv "$VENV_DIR"
+
+info "Instalando librerías Python (puede tardar varios minutos)..."
+"$VENV_DIR/bin/pip" install --upgrade pip --quiet
+"$VENV_DIR/bin/pip" install faster-whisper sounddevice numpy pynput --quiet
+
+# ── Copiar archivos ───────────────────────────────────────────────────────────
+info "Instalando archivos..."
+mkdir -p "$HOME/.local/bin"
+cp whisper-dictation.py "$HOME/.local/bin/whisper-dictation.py"
+cp dictate "$HOME/.local/bin/dictate"
+chmod +x "$HOME/.local/bin/dictate"
+
+# ── Servicio systemd ──────────────────────────────────────────────────────────
+info "Configurando servicio systemd..."
+mkdir -p "$HOME/.config/systemd/user"
+cp whisper-dictation.service "$HOME/.config/systemd/user/whisper-dictation.service"
+systemctl --user daemon-reload
+systemctl --user enable whisper-dictation
+systemctl --user start whisper-dictation
+
+# ── Verificar ~/.local/bin en PATH ───────────────────────────────────────────
+if [[ ":$PATH:" != *":$HOME/.local/bin:"* ]]; then
+    warn "~/.local/bin no está en tu PATH."
+    warn "Agrega esta línea a tu ~/.bashrc o ~/.zshrc:"
+    echo "    export PATH=\"\$HOME/.local/bin:\$PATH\""
+fi
+
+echo ""
+info "¡Instalación completada!"
+echo ""
+echo "  Mantén presionada F12 para dictar."
+echo "  Estado del servicio:"
+systemctl --user status whisper-dictation --no-pager -l || true
+echo ""

--- a/whisper-dictation.py
+++ b/whisper-dictation.py
@@ -1,0 +1,199 @@
+#!/usr/bin/env python3
+"""
+Push-to-talk dictation para Linux X11 + KDE.
+Mantén presionada F12 para grabar. Al soltar, transcribe y escribe.
+
+Uso:
+  python3 whisper-dictation.py            # Tecla por defecto: F12
+  python3 whisper-dictation.py --key F10  # Cambiar tecla
+  python3 whisper-dictation.py --toggle   # Modo toggle
+  python3 whisper-dictation.py --model medium  # Modelo más preciso
+"""
+
+import argparse
+import subprocess
+import threading
+import time
+import numpy as np
+import sounddevice as sd
+from faster_whisper import WhisperModel
+from pynput import keyboard
+
+# ---------- Configuración por defecto ----------
+DEFAULT_KEY      = "f12"
+DEFAULT_MODEL    = "base"   # tiny | base | small | medium | large-v3
+DEFAULT_LANGUAGE = "es"     # None = autodetección
+SAMPLE_RATE      = 16000
+CHANNELS         = 1
+# -----------------------------------------------
+
+def notify(title, message, timeout=3):
+    """Notificación visual en KDE (no bloqueante)."""
+    try:
+        subprocess.Popen(
+            ["kdialog", "--passivepopup", f"{message}", str(timeout),
+             "--title", title],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+    except FileNotFoundError:
+        pass  # Si kdialog no está disponible, continúa sin notificación
+
+
+class Dictation:
+    def __init__(self, model_name, language, toggle_mode):
+        print(f"[Whisper Dictation] Cargando modelo '{model_name}'...")
+        notify("Whisper Dictation", "⏳ Cargando modelo, espera un momento...", 5)
+        self.model = WhisperModel(
+            model_name,
+            device="cpu",
+            compute_type="int8",
+        )
+        self.language = language
+        self.toggle_mode = toggle_mode
+        self.recording = False
+        self.audio_frames = []
+        self.lock = threading.Lock()
+        print(f"[Whisper Dictation] Listo. Idioma: {language or 'auto'}")
+        notify("Whisper Dictation", "✅ Listo — mantén F12 para dictar", 4)
+
+    def start_recording(self):
+        with self.lock:
+            if self.recording:
+                return
+            self.recording = True
+            self.audio_frames = []
+        print("[●] Grabando...", flush=True)
+        notify("🎙 Dictado", "Grabando... suelta F12 para transcribir", 30)
+        self._stream = sd.InputStream(
+            samplerate=SAMPLE_RATE,
+            channels=CHANNELS,
+            dtype="float32",
+            callback=self._audio_callback,
+        )
+        self._stream.start()
+
+    def _audio_callback(self, indata, frames, time_info, status):
+        with self.lock:
+            if self.recording:
+                self.audio_frames.append(indata.copy())
+
+    def stop_and_transcribe(self):
+        with self.lock:
+            if not self.recording:
+                return
+            self.recording = False
+        self._stream.stop()
+        self._stream.close()
+        print("[■] Procesando...", flush=True)
+        notify("🎙 Dictado", "⏳ Procesando audio...", 10)
+
+        if not self.audio_frames:
+            print("[!] Sin audio grabado.")
+            notify("🎙 Dictado", "⚠️ Sin audio grabado", 3)
+            return
+
+        audio = np.concatenate(self.audio_frames, axis=0).flatten()
+
+        if len(audio) < SAMPLE_RATE * 0.5:
+            print("[!] Grabación muy corta, ignorada.")
+            notify("🎙 Dictado", "⚠️ Grabación muy corta, ignorada", 3)
+            return
+
+        segments, info = self.model.transcribe(
+            audio,
+            language=self.language,
+            beam_size=5,
+            vad_filter=True,
+            vad_parameters=dict(min_silence_duration_ms=500),
+        )
+
+        text = " ".join(seg.text for seg in segments).strip()
+
+        if text:
+            print(f'[✓] "{text}"', flush=True)
+            notify("✅ Transcripción", text, 5)
+            self._type_text(text)
+        else:
+            print("[!] No se detectó habla.")
+            notify("🎙 Dictado", "⚠️ No se detectó habla", 3)
+
+    def _type_text(self, text):
+        # Pausa para que F12 se suelte antes de escribir
+        time.sleep(0.15)
+        try:
+            subprocess.run(
+                ["xdotool", "type", "--clearmodifiers", "--delay", "0", "--", text],
+                check=True,
+            )
+        except subprocess.CalledProcessError as e:
+            print(f"[Error xdotool] {e}")
+        except FileNotFoundError:
+            print("[Error] xdotool no encontrado. Instalar con: sudo apt install xdotool")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Push-to-talk dictation con Whisper")
+    parser.add_argument("--key", default=DEFAULT_KEY,
+                        help=f"Tecla para activar (default: {DEFAULT_KEY})")
+    parser.add_argument("--model", default=DEFAULT_MODEL,
+                        choices=["tiny", "base", "small", "medium", "large-v3"],
+                        help=f"Modelo Whisper (default: {DEFAULT_MODEL})")
+    parser.add_argument("--language", default=DEFAULT_LANGUAGE,
+                        help="Código de idioma ISO (es, en, fr...) o 'auto'")
+    parser.add_argument("--toggle", action="store_true",
+                        help="Modo toggle: presionar una vez inicia, presionar de nuevo detiene")
+    args = parser.parse_args()
+
+    language = None if args.language == "auto" else args.language
+    dictation = Dictation(args.model, language, args.toggle)
+
+    mode = "toggle" if args.toggle else "mantener presionada"
+    print(f"[Whisper Dictation] Tecla activa: {args.key.upper()} ({mode})")
+    print("[Whisper Dictation] Ctrl+C para salir\n")
+
+    pressed = False
+
+    def on_press(key):
+        nonlocal pressed
+        try:
+            key_name = key.name if hasattr(key, "name") else key.char
+        except AttributeError:
+            return
+
+        if key_name == args.key.lower():
+            if args.toggle:
+                if not pressed:
+                    pressed = True
+                    dictation.start_recording()
+                else:
+                    pressed = False
+                    threading.Thread(target=dictation.stop_and_transcribe, daemon=True).start()
+            else:
+                if not pressed:
+                    pressed = True
+                    dictation.start_recording()
+
+    def on_release(key):
+        nonlocal pressed
+        if args.toggle:
+            return
+        try:
+            key_name = key.name if hasattr(key, "name") else key.char
+        except AttributeError:
+            return
+
+        if key_name == args.key.lower():
+            if pressed:
+                pressed = False
+                threading.Thread(target=dictation.stop_and_transcribe, daemon=True).start()
+
+    with keyboard.Listener(on_press=on_press, on_release=on_release) as listener:
+        try:
+            listener.join()
+        except KeyboardInterrupt:
+            print("\n[Whisper Dictation] Saliendo.")
+            notify("Whisper Dictation", "🔴 Servicio detenido", 3)
+
+if __name__ == "__main__":
+    main()

--- a/whisper-dictation.service
+++ b/whisper-dictation.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=Whisper Push-to-Talk Dictation
+After=graphical-session.target
+PartOf=graphical-session.target
+
+[Service]
+Type=simple
+ExecStart=%h/.local/bin/dictate
+Restart=on-failure
+RestartSec=5
+Environment=DISPLAY=:0
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=graphical-session.target


### PR DESCRIPTION
## Description

First functional release of whisper-ptt: a push-to-talk dictation tool
for Linux using OpenAI Whisper completely offline. Hold a key to record
your voice and the transcribed text is automatically typed wherever your
cursor is — no internet, no APIs, works in any application.

## Changes

- `whisper-dictation.py` — Core script: captures audio with sounddevice,
  transcribes with faster-whisper (int8/CPU) and types the result with
  xdotool. Supports hold and toggle modes, configurable key, model
  selection and language.

- `dictate` — Bash wrapper that activates the virtualenv and launches
  the script, allowing users to run `dictate` without manual environment
  activation.

- `whisper-dictation.service` — systemd user service for automatic
  startup on login, with restart on failure. Uses `%h` specifier for
  portability across any user account.

- `install.sh` — Automated installer: installs system dependencies,
  creates the Python virtualenv, installs required libraries and
  configures the systemd service.

- `README.md` — Full documentation with installation steps, usage
  instructions, advanced CLI options and available model comparison.

## Version

`v0.1.0` — Initial functional release.

## Tested on

- Debian 12 (Bookworm) + KDE Plasma + X11
