### PR TITLE
docs: propose frontend GUI for whisper-ptt

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,5 +56,11 @@ journalctl --user -u whisper-dictation -f
 ## Probado en
 - Debian 12 (Bookworm) + KDE Plasma + X11
 
+## Frontend proposal
+A frontend proposal for visual configuration and operation is documented in:
+- `docs/frontend/FRONTEND-PROPOSAL.md`
+- `docs/frontend/UI-FLOWS.md`
+- `docs/frontend/IMPLEMENTATION-PLAN.md`
+
 ## Licencia
 MIT

--- a/README.md
+++ b/README.md
@@ -87,11 +87,23 @@ journalctl --user -u whisper-dictation -n 50 --no-pager
 ## Probado en
 - Debian 12 (Bookworm) + KDE Plasma + X11
 
-## Frontend proposal
-A frontend proposal for visual configuration and operation is documented in:
+## Frontend GUI
+La primera iteración funcional de GUI ya incluye:
+- pantalla de estado del servicio
+- configuración visual de tecla, idioma, modelo y modo toggle
+- recarga de logs del servicio
+- operaciones de iniciar, detener y reiniciar servicio
+
+Para abrir la GUI instalada:
+```bash
+whisper-ptt-gui
+```
+
+Documentación de frontend:
 - `docs/frontend/FRONTEND-PROPOSAL.md`
 - `docs/frontend/UI-FLOWS.md`
 - `docs/frontend/IMPLEMENTATION-PLAN.md`
+- `docs/frontend/TKINTER-THREADING-ARCHITECTURE.md`
 
 ## Licencia
 MIT

--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ en cualquier aplicación.
 bash install.sh
 ```
 
+El instalador detecta automáticamente si está corriendo por primera vez (`INSTALL`) o si está actualizando una instalación existente (`UPDATE`).
+
 ## Uso
 | Acción | Resultado |
 |--------|-----------|
@@ -31,10 +33,12 @@ bash install.sh
 
 ### Opciones avanzadas
 ```bash
-dictate --key F10          # Cambiar tecla
-dictate --model medium     # Más preciso (más lento)
-dictate --language auto    # Detectar idioma automáticamente
-dictate --toggle           # Modo toggle en vez de mantener presionado
+dictate --key F10                # Cambiar tecla
+dictate --model medium           # Más preciso (más lento)
+dictate --model distil-large-v3  # Variante distil-whisper
+dictate --language auto          # Detectar idioma automáticamente
+dictate --toggle                 # Modo toggle en vez de mantener presionado
+dictate --download-all           # Pre-descarga todos los modelos registrados
 ```
 
 ### Controlar el servicio
@@ -48,10 +52,14 @@ journalctl --user -u whisper-dictation -f
 ## Modelos disponibles
 | Modelo | Velocidad | Precisión | RAM aprox |
 |--------|-----------|-----------|-----------|
-| tiny   | Muy rápido | Básica   | 200 MB    |
-| base   | Rápido     | Buena    | 300 MB    |
-| small  | Medio      | Muy buena| 500 MB    |
-| medium | Lento      | Excelente| 1.5 GB    |
+| tiny / tiny.en | Muy rápido | Básica | 200 MB |
+| base / base.en | Rápido | Buena | 300 MB |
+| small / small.en | Medio | Muy buena | 500 MB |
+| medium / medium.en | Lento | Excelente | 1.5 GB |
+| large-v1 / large-v2 / large-v3 / large-v3-turbo | Más lento | Máxima | 2-3+ GB |
+| distil-small.en / distil-medium.en / distil-large-v2 / distil-large-v3 | Optimizado | Muy alta | variable |
+
+Si un modelo no está cacheado localmente, se descarga automáticamente antes del primer uso con una notificación visible.
 
 ## Probado en
 - Debian 12 (Bookworm) + KDE Plasma + X11

--- a/README.md
+++ b/README.md
@@ -19,15 +19,39 @@ en cualquier aplicación.
 - xdotool y portaudio19-dev
 
 ## Instalación
+### Paso a paso
+1. Clona este repositorio.
+2. Entra al directorio del proyecto.
+3. Ejecuta el instalador:
+
 ```bash
+git clone https://github.com/andresTNS/linux-push-to-talk.git
+cd linux-push-to-talk
 bash install.sh
 ```
+
+El instalador:
+- verifica e instala dependencias del sistema
+- crea el entorno virtual en `~/.local/share/whisper-dictation`
+- instala dependencias Python
+- copia los binarios a `~/.local/bin`
+- habilita e inicia el servicio `whisper-dictation`
+
+Guía completa de instalación y pruebas:
+- `docs/INSTALLATION-AND-TESTING.md`
 
 ## Uso
 | Acción | Resultado |
 |--------|-----------|
 | Mantener F12 | Inicia grabación |
 | Soltar F12 | Transcribe y escribe el texto |
+
+### Cómo probar que funciona
+1. Abre una aplicación donde puedas escribir.
+2. Mantén presionada `F12`.
+3. Habla durante unos segundos.
+4. Suelta `F12`.
+5. Verifica que el texto se escriba automáticamente en la ventana activa.
 
 ### Opciones avanzadas
 ```bash
@@ -43,6 +67,13 @@ systemctl --user status whisper-dictation
 systemctl --user restart whisper-dictation
 systemctl --user stop whisper-dictation
 journalctl --user -u whisper-dictation -f
+```
+
+### Validaciones rápidas
+```bash
+which dictate
+systemctl --user status whisper-dictation
+journalctl --user -u whisper-dictation -n 50 --no-pager
 ```
 
 ## Modelos disponibles

--- a/docs/INSTALLATION-AND-TESTING.md
+++ b/docs/INSTALLATION-AND-TESTING.md
@@ -1,0 +1,182 @@
+# Instalación y prueba paso a paso
+
+Esta guía explica cómo dejar `whisper-ptt` funcionando en Linux y cómo comprobar que quedó correctamente instalado.
+
+## 1. Requisitos previos
+
+Antes de instalar, verifica que tu entorno cumpla con lo siguiente:
+
+- Linux con X11
+- Python 3.9 o superior
+- `sudo` disponible para instalar dependencias del sistema
+- Una aplicación abierta donde puedas escribir texto para probar el dictado
+
+Dependencias del sistema usadas por el proyecto:
+
+- `python3`
+- `xdotool`
+- `libportaudio2`
+- `portaudio19-dev`
+
+## 2. Clonar el repositorio
+
+```bash
+git clone https://github.com/andresTNS/linux-push-to-talk.git
+cd linux-push-to-talk
+```
+
+## 3. Ejecutar el instalador
+
+```bash
+bash install.sh
+```
+
+El instalador realiza estas acciones:
+
+1. verifica dependencias del sistema
+2. instala paquetes faltantes con `apt-get` si hace falta
+3. crea un entorno virtual en `~/.local/share/whisper-dictation`
+4. instala las librerías Python necesarias
+5. copia `dictate` y `whisper-dictation.py` a `~/.local/bin`
+6. instala y activa el servicio `whisper-dictation` en `systemd --user`
+
+Importante: no ejecutes `install.sh` como `root`.
+
+## 4. Verificar que la instalación quedó correcta
+
+Comprueba que el binario exista:
+
+```bash
+which dictate
+```
+
+Debería resolver a una ruta dentro de `~/.local/bin`.
+
+Comprueba que el servicio esté activo:
+
+```bash
+systemctl --user status whisper-dictation
+```
+
+Si quieres reiniciarlo manualmente:
+
+```bash
+systemctl --user restart whisper-dictation
+```
+
+Si quieres ver logs en vivo:
+
+```bash
+journalctl --user -u whisper-dictation -f
+```
+
+## 5. Primera prueba funcional
+
+1. abre un editor de texto, navegador o cualquier campo donde puedas escribir
+2. mantén presionada `F12`
+3. habla con claridad durante 1 a 3 segundos
+4. suelta `F12`
+5. espera a que termine el procesamiento
+6. confirma que el texto aparezca donde estaba el cursor
+
+Si todo está bien, el flujo esperado es:
+
+- aparece notificación de grabación
+- luego aparece notificación de procesamiento
+- finalmente el texto se escribe automáticamente en la ventana activa
+
+## 6. Pruebas recomendadas
+
+### Prueba básica
+
+- dicta una frase corta en español
+- confirma que el texto se inserta correctamente
+
+### Prueba de ventana activa
+
+- repite la prueba en distintas aplicaciones
+- por ejemplo: navegador, editor de texto, terminal, chat
+
+### Prueba de idioma
+
+```bash
+dictate --language auto
+```
+
+Luego dicta en otro idioma y verifica el resultado.
+
+### Prueba de precisión
+
+```bash
+dictate --model medium
+```
+
+Esto usa un modelo más preciso, pero más lento y con mayor consumo de RAM.
+
+### Prueba de tecla alternativa
+
+```bash
+dictate --key F10
+```
+
+Útil si `F12` está ocupada por otra aplicación o atajo del escritorio.
+
+### Prueba de modo toggle
+
+```bash
+dictate --toggle
+```
+
+En este modo:
+
+- una pulsación inicia la grabación
+- la siguiente pulsación la detiene y dispara la transcripción
+
+## 7. Solución rápida de problemas
+
+### `dictate` no se encuentra
+
+Agrega `~/.local/bin` a tu `PATH`:
+
+```bash
+export PATH="$HOME/.local/bin:$PATH"
+```
+
+Luego agrega esa línea a tu `~/.bashrc` o `~/.zshrc`.
+
+### El servicio no inicia
+
+Revisa:
+
+```bash
+systemctl --user status whisper-dictation
+journalctl --user -u whisper-dictation -n 100 --no-pager
+```
+
+### No escribe texto en la aplicación
+
+Verifica que:
+
+- estés usando X11
+- `xdotool` esté instalado
+- la ventana destino tenga el foco
+
+### No captura audio
+
+Verifica que:
+
+- el micrófono funcione en el sistema
+- tengas permisos para usar el dispositivo de audio
+- `libportaudio2` esté instalado
+
+## 8. Comandos útiles
+
+```bash
+dictate --key F10
+dictate --model medium
+dictate --language auto
+dictate --toggle
+systemctl --user status whisper-dictation
+systemctl --user restart whisper-dictation
+journalctl --user -u whisper-dictation -f
+```

--- a/docs/frontend/FRONTEND-PROPOSAL.md
+++ b/docs/frontend/FRONTEND-PROPOSAL.md
@@ -39,9 +39,15 @@ The frontend is not intended to replace the CLI. It should sit on top of the exi
 
 ## Recommended technical direction
 
-### Recommended MVP stack
+### Required MVP stack
 
-**Python + Tkinter**
+**Python + Tkinter only**
+
+This proposal now follows the explicit direction requested by the repository owner in issue #6:
+- use Tkinter exclusively for the first functional iteration,
+- avoid heavier GUI dependencies,
+- preserve low resource usage on limited hardware,
+- keep packaging and runtime footprint simple.
 
 Why:
 - matches the current Python-based project,
@@ -110,6 +116,23 @@ Should show:
 - recent `systemd --user` logs,
 - a simple self-check result.
 
+## Threading and responsiveness model
+
+The GUI must remain responsive even while background dictation and service operations are happening.
+
+Required design:
+- Tkinter main thread owns all UI updates.
+- Keyboard capture and long-running operations must run outside the UI thread.
+- Communication back to the GUI should happen through thread-safe queues or scheduled UI polling via `after(...)`.
+- Service actions, diagnostics, and model-management tasks must never block the main window.
+
+Minimum worker separation for first functional iteration:
+- UI thread: windows, widgets, rendering, user actions
+- background worker: service status refresh, diagnostics, install/update actions
+- dictation/event worker: hotkey/event capture and runtime coordination when needed
+
+This separation is mandatory to avoid frozen windows and "not responding" states.
+
 ## Configuration model
 
 The frontend should introduce a single local config file owned by the user, for example:
@@ -167,9 +190,12 @@ The frontend should leverage that evolution rather than fork from it conceptuall
 ## Deliverable target
 
 A first implementation should produce:
-- a runnable local GUI,
+- a runnable local Tkinter GUI,
 - service start/stop/restart,
 - editable settings persisted to config,
+- automated hotkey configuration from the UI,
+- immediate visual microphone/status feedback,
 - model selection and download actions,
 - diagnostic panel,
-- logs view.
+- logs view,
+- installation and deployment guidance for Linux environments.

--- a/docs/frontend/FRONTEND-PROPOSAL.md
+++ b/docs/frontend/FRONTEND-PROPOSAL.md
@@ -1,0 +1,175 @@
+# Frontend Proposal — whisper-ptt
+
+Issue: #6
+Branch: `feature/issue-6-frontend-proposal`
+Base: `dev`
+
+## Objective
+
+Design a lightweight graphical frontend for `whisper-ptt` that preserves the project's offline-first, minimal, Linux-native philosophy while reducing setup and operational friction for non-technical users.
+
+The frontend is not intended to replace the CLI. It should sit on top of the existing scripts and service model, exposing the most important controls visually.
+
+## Product principles
+
+1. **Offline first**
+   - No cloud dependency.
+   - No telemetry by default.
+   - No account model.
+
+2. **Thin layer over the current system**
+   - Reuse `install.sh`, `dictate`, `whisper-dictation.py`, and `systemd --user` service behavior.
+   - Avoid duplicating configuration logic in multiple places.
+
+3. **Operator clarity**
+   - The user should immediately understand:
+     - whether the service is running,
+     - which model is active,
+     - which language is active,
+     - which hotkey is configured,
+     - and whether dependencies are healthy.
+
+4. **Safe progressive complexity**
+   - The default view should be simple.
+   - Advanced controls should exist, but remain secondary.
+
+5. **Consistent with the current project scope**
+   - Linux desktop utility.
+   - X11-first today, with room for future Wayland strategy.
+
+## Recommended technical direction
+
+### Recommended MVP stack
+
+**Python + Tkinter**
+
+Why:
+- matches the current Python-based project,
+- minimal extra dependencies,
+- easier to maintain for an open-source utility,
+- enough for configuration, service control and diagnostics.
+
+### Alternatives considered
+
+#### PySide / Qt
+Pros:
+- better UX,
+- stronger widget set,
+- more scalable long term.
+
+Cons:
+- heavier dependency surface,
+- more packaging complexity,
+- likely overkill for first usable version.
+
+#### Tauri / Web frontend
+Pros:
+- modern UX,
+- future-friendly.
+
+Cons:
+- introduces a second application stack,
+- higher build/distribution complexity,
+- drifts from the current philosophy of simple offline utility.
+
+## MVP scope
+
+### 1. Status screen
+Purpose: answer "is it working?"
+
+Should show:
+- service status: active / inactive / failed,
+- configured hotkey,
+- selected model,
+- selected language,
+- install mode / update state if known,
+- quick buttons:
+  - start service,
+  - stop service,
+  - restart service,
+  - open logs.
+
+### 2. Configuration screen
+Purpose: answer "how do I set it up?"
+
+Should allow editing:
+- hotkey,
+- push-to-talk mode vs toggle mode,
+- language (`es`, `en`, `auto`, etc.),
+- model selection from registry,
+- download current model,
+- pre-download all models.
+
+### 3. Diagnostics screen
+Purpose: answer "why is it failing?"
+
+Should show:
+- presence of `xdotool`, `xclip`, PortAudio,
+- Python env presence,
+- model cache visibility,
+- recent `systemd --user` logs,
+- a simple self-check result.
+
+## Configuration model
+
+The frontend should introduce a single local config file owned by the user, for example:
+
+`~/.config/whisper-dictation/config.json`
+
+Suggested fields:
+- `key`
+- `toggle`
+- `language`
+- `model`
+- `downloaded_models`
+- `typing_mode` (`xdotool` / `xclip+paste` fallback preference)
+
+The CLI and service wrapper should eventually read from the same config source to avoid drift.
+
+## Service integration
+
+The frontend should not implement background dictation itself.
+
+Instead, it should:
+- read state from the existing user service,
+- update config,
+- restart service when needed,
+- surface logs and operational status.
+
+This keeps the GUI thin and consistent with the current architecture.
+
+## UX guidelines
+
+- one-window application,
+- no modal-heavy flow,
+- visible status at top,
+- safe defaults,
+- explicit error messages,
+- copyable diagnostic output for issue reports.
+
+## Relation to current branches
+
+This proposal should build on the direction already visible in `feat/mejoras-generales`, especially around:
+- better installation/update handling,
+- richer model selection,
+- improved operational behavior.
+
+The frontend should leverage that evolution rather than fork from it conceptually.
+
+## Non-goals for MVP
+
+- Wayland-native injection support,
+- audio waveform editor,
+- account sync,
+- cloud model providers,
+- packaging for every distro format on day one.
+
+## Deliverable target
+
+A first implementation should produce:
+- a runnable local GUI,
+- service start/stop/restart,
+- editable settings persisted to config,
+- model selection and download actions,
+- diagnostic panel,
+- logs view.

--- a/docs/frontend/IMPLEMENTATION-PLAN.md
+++ b/docs/frontend/IMPLEMENTATION-PLAN.md
@@ -1,0 +1,130 @@
+# Implementation Plan — whisper-ptt frontend
+
+Issue: #6
+
+## Goal
+
+Translate the frontend proposal into an incremental implementation path that remains compatible with the current CLI + systemd architecture.
+
+## Phase 0 — Preparation
+
+Before coding the GUI:
+- consolidate the operational config model,
+- define a single config file location,
+- make the runtime read configuration from that file,
+- keep CLI flags as overrides where appropriate.
+
+### Expected output
+- `config.json` schema defined,
+- read/write helpers implemented,
+- service wrapper capable of launching with persisted config.
+
+## Phase 1 — MVP GUI shell
+
+Build a minimal Python Tkinter app with:
+- top status banner,
+- tabs or left navigation,
+- service controls,
+- current config readout.
+
+### Acceptance
+- GUI opens,
+- reads config,
+- checks service state,
+- start/stop/restart buttons work.
+
+## Phase 2 — Configuration editor
+
+Add editable controls for:
+- hotkey,
+- toggle mode,
+- language,
+- model selection.
+
+### Acceptance
+- user can save config without touching terminal,
+- service restart applies changes,
+- invalid inputs are blocked or explained.
+
+## Phase 3 — Model management
+
+Add:
+- current model visibility,
+- on-demand model download,
+- `download all` action,
+- progress feedback where feasible.
+
+### Acceptance
+- missing model can be downloaded from GUI,
+- current model can be switched visually,
+- registry options remain aligned with backend support.
+
+## Phase 4 — Diagnostics
+
+Add health panel for:
+- dependencies,
+- service logs,
+- model cache presence,
+- typing path capability.
+
+### Acceptance
+- GUI identifies the most common failure modes,
+- user can copy diagnostic text for issue reporting.
+
+## Phase 5 — Packaging polish
+
+Optional after MVP:
+- desktop entry,
+- icon,
+- launcher integration,
+- distro-specific packaging.
+
+## Architecture notes
+
+Recommended frontend module split:
+- `frontend/app.py` — entrypoint
+- `frontend/service.py` — systemd interaction
+- `frontend/config.py` — config read/write
+- `frontend/models.py` — model registry / downloads
+- `frontend/diagnostics.py` — checks / report generation
+- `frontend/views/*.py` — UI panels
+
+## Risks
+
+1. **Config drift**
+   - If GUI config and CLI flags diverge, support becomes confusing.
+   - Mitigation: one canonical config source.
+
+2. **Desktop environment variance**
+   - Different Linux environments may behave differently.
+   - Mitigation: MVP should target the currently documented X11 path first.
+
+3. **Model availability / cache assumptions**
+   - Heuristics for downloaded models may become brittle.
+   - Mitigation: centralize registry/cache logic.
+
+4. **Text injection reliability**
+   - GUI cannot solve every injection-path issue by itself.
+   - Mitigation: expose current typing strategy and diagnostics.
+
+## Recommended first implementation milestone
+
+Implement only this first:
+- status screen,
+- configuration screen,
+- service controls,
+- saved config,
+- model dropdown.
+
+That gives real user value without overbuilding.
+
+## Relationship with open-source maintenance
+
+This issue should be treated as a proposal/specification milestone, not as a promise to implement the full GUI immediately.
+
+A good outcome for this issue is:
+- clear proposal,
+- clear screens,
+- clear architecture,
+- clear incremental roadmap,
+- clear boundary between GUI and backend.

--- a/docs/frontend/IMPLEMENTATION-PLAN.md
+++ b/docs/frontend/IMPLEMENTATION-PLAN.md
@@ -4,7 +4,15 @@ Issue: #6
 
 ## Goal
 
-Translate the frontend proposal into an incremental implementation path that remains compatible with the current CLI + systemd architecture.
+Translate the frontend proposal into an incremental implementation path that remains compatible with the current CLI + systemd architecture and aligns with the owner guidance in issue #6.
+
+Owner constraints now incorporated into this plan:
+- Tkinter only for the first functional iteration,
+- robust behavior on low-resource Linux hardware,
+- strict separation between GUI and keyboard/event logic,
+- installation and deployment guide as part of the deliverable,
+- atomic commits with Conventional Commits during implementation,
+- every implementation commit linked back to issue #6.
 
 ## Phase 0 — Preparation
 
@@ -25,13 +33,16 @@ Build a minimal Python Tkinter app with:
 - top status banner,
 - tabs or left navigation,
 - service controls,
-- current config readout.
+- current config readout,
+- clear microphone state indicator,
+- non-blocking background refresh for service state.
 
 ### Acceptance
 - GUI opens,
 - reads config,
 - checks service state,
-- start/stop/restart buttons work.
+- start/stop/restart buttons work,
+- UI remains responsive while status checks run.
 
 ## Phase 2 — Configuration editor
 
@@ -87,7 +98,15 @@ Recommended frontend module split:
 - `frontend/config.py` — config read/write
 - `frontend/models.py` — model registry / downloads
 - `frontend/diagnostics.py` — checks / report generation
+- `frontend/hotkey.py` — keyboard/event orchestration outside the UI thread
+- `frontend/runtime_queue.py` — thread-safe message passing to Tkinter
 - `frontend/views/*.py` — UI panels
+
+Threading rules:
+- all Tkinter widget updates happen only on the main thread,
+- blocking work runs in workers,
+- workers communicate results to the UI through a queue,
+- the UI consumes events through periodic `after(...)` polling.
 
 ## Risks
 
@@ -109,22 +128,28 @@ Recommended frontend module split:
 
 ## Recommended first implementation milestone
 
-Implement only this first:
+Implement this first functional milestone:
 - status screen,
 - configuration screen,
 - service controls,
 - saved config,
-- model dropdown.
+- model dropdown,
+- hotkey configuration from UI,
+- microphone/status feedback,
+- installation/testing guide aligned with Linux deployment.
 
-That gives real user value without overbuilding.
+That gives real user value without overbuilding while still honoring the owner's request for a usable first iteration.
 
-## Relationship with open-source maintenance
+## Commit discipline for implementation
 
-This issue should be treated as a proposal/specification milestone, not as a promise to implement the full GUI immediately.
+When implementation starts, use this delivery discipline:
+- one file changed per commit,
+- Conventional Commits naming,
+- each commit body references issue `#6`,
+- keep GUI and runtime changes traceable by layer.
 
-A good outcome for this issue is:
-- clear proposal,
-- clear screens,
-- clear architecture,
-- clear incremental roadmap,
-- clear boundary between GUI and backend.
+Suggested examples:
+- `feat(frontend): add tkinter app shell`
+- `feat(frontend): add config loader`
+- `feat(frontend): add service status panel`
+- `docs(frontend): add linux deployment notes`

--- a/docs/frontend/TKINTER-THREADING-ARCHITECTURE.md
+++ b/docs/frontend/TKINTER-THREADING-ARCHITECTURE.md
@@ -1,0 +1,94 @@
+# Tkinter Threading Architecture — whisper-ptt
+
+Issue: #6
+
+## Purpose
+
+Define a safe threading model for the first functional GUI iteration so the interface remains responsive while the runtime performs service checks, diagnostics, and configuration actions.
+
+## Constraint
+
+Tkinter is not thread-safe.
+
+Because of that:
+- the main thread must own all widget creation and updates,
+- background work must not directly touch widgets,
+- worker results must be marshalled back to the UI safely.
+
+## Proposed model
+
+### 1. UI thread
+Responsibilities:
+- create the root window
+- render status, configuration, diagnostics, and logs views
+- handle button clicks and form events
+- consume messages from workers and refresh widgets
+
+Allowed operations:
+- `tkinter` widgets
+- `after(...)` polling
+- lightweight state transitions
+
+Forbidden operations:
+- long-running subprocess calls
+- blocking diagnostics
+- model download work
+- keyboard/event loops that can stall rendering
+
+### 2. Service/diagnostics worker
+Responsibilities:
+- query `systemctl --user` state
+- read recent logs
+- run dependency checks
+- detect config and cache health
+- execute install/update/restart workflows
+
+Output channel:
+- push structured events into a thread-safe queue consumed by the UI thread
+
+### 3. Runtime/event worker
+Responsibilities:
+- isolate keyboard/event-related runtime behavior from the GUI
+- coordinate hotkey-related configuration or monitoring tasks
+- keep event handling independent from Tkinter repaint cycles
+
+Output channel:
+- emit runtime state changes into the same queue abstraction
+
+## Event flow
+
+1. User triggers an action in the GUI.
+2. UI thread validates the request and dispatches work to a worker.
+3. Worker executes the blocking operation.
+4. Worker posts a structured result event.
+5. Tkinter main thread consumes the event via scheduled polling.
+6. UI updates status badges, forms, logs, or error banners.
+
+## Suggested event types
+
+- `service_status_changed`
+- `service_logs_loaded`
+- `diagnostic_result_ready`
+- `config_saved`
+- `model_download_started`
+- `model_download_finished`
+- `runtime_error`
+- `microphone_state_changed`
+
+## Stability rules
+
+- no direct widget mutation from worker threads
+- no infinite blocking call inside button handlers
+- no synchronous shell command tied directly to repaint-sensitive flows
+- every background task must surface errors explicitly to the UI
+- status polling frequency should be conservative to avoid unnecessary CPU usage on low-resource machines
+
+## Initial implementation recommendation
+
+Start with this minimum architecture:
+- one Tkinter app shell
+- one shared queue
+- one worker for service/diagnostics tasks
+- one polling loop with `root.after(...)`
+
+That is enough for the first usable iteration and preserves a clean path for later growth.

--- a/docs/frontend/UI-FLOWS.md
+++ b/docs/frontend/UI-FLOWS.md
@@ -1,0 +1,119 @@
+# UI Flows — whisper-ptt frontend
+
+Issue: #6
+
+## Primary flow 1 — First-time setup
+
+1. User opens the app.
+2. Frontend checks:
+   - whether user service exists,
+   - whether dependencies are installed,
+   - whether a model is already available,
+   - whether local config exists.
+3. If missing pieces are detected, the app shows a guided setup state:
+   - install / update,
+   - choose language,
+   - choose hotkey,
+   - choose model,
+   - optional model download.
+4. App writes config.
+5. App starts or restarts `whisper-dictation` service.
+6. User sees final validation state.
+
+## Primary flow 2 — Daily operation
+
+1. User opens the app.
+2. Status screen shows:
+   - service active,
+   - current hotkey,
+   - current model,
+   - current language,
+   - latest known diagnostics state.
+3. User optionally changes model or language.
+4. App persists config and offers restart.
+
+## Primary flow 3 — Troubleshooting
+
+1. User opens Diagnostics.
+2. App runs health checks:
+   - binary availability,
+   - service state,
+   - access to logs,
+   - config parse check,
+   - model cache visibility.
+3. App marks each item:
+   - OK,
+   - warning,
+   - error.
+4. User can copy diagnostics output for a GitHub issue.
+
+## Screen layout proposal
+
+## Header
+Visible on all screens:
+- app title,
+- service status badge,
+- configured model,
+- quick restart button.
+
+## Left navigation
+- Status
+- Configuration
+- Diagnostics
+- About
+
+## Status screen
+Sections:
+- Service state
+- Active configuration
+- Quick actions
+- Recent log tail
+
+## Configuration screen
+Sections:
+- Hotkey
+- Toggle mode
+- Language
+- Model selector
+- Download actions
+- Save + restart
+
+## Diagnostics screen
+Sections:
+- Dependencies
+- Service health
+- Cache health
+- Typing path health (`xdotool`, `xclip`)
+- Logs
+- Copy diagnostic report
+
+## About screen
+Sections:
+- project summary,
+- version,
+- links to README / repo / issues.
+
+## Error handling principles
+
+- show the exact failing subsystem,
+- avoid vague 'something went wrong',
+- suggest next action,
+- allow copying technical details.
+
+## Suggested status language
+
+- Service running
+- Service stopped
+- Service failed
+- Model not downloaded
+- Missing dependency
+- Config updated, restart required
+- Ready to dictate
+
+## Design tone
+
+- sober,
+- compact,
+- utilitarian,
+- consistent with a Linux desktop utility,
+- no unnecessary animation or branding weight.

--- a/frontend-config.json.example
+++ b/frontend-config.json.example
@@ -1,0 +1,6 @@
+{
+  "key": "f12",
+  "toggle": false,
+  "language": "es",
+  "model": "base"
+}

--- a/frontend_config.py
+++ b/frontend_config.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+import json
+from pathlib import Path
+
+CONFIG_DIR = Path.home() / ".config" / "whisper-dictation"
+CONFIG_PATH = CONFIG_DIR / "config.json"
+DEFAULT_CONFIG = {
+    "key": "f12",
+    "toggle": False,
+    "language": "es",
+    "model": "base",
+}
+
+
+def load_config():
+    if not CONFIG_PATH.exists():
+        return DEFAULT_CONFIG.copy()
+    try:
+        data = json.loads(CONFIG_PATH.read_text())
+    except (json.JSONDecodeError, OSError):
+        return DEFAULT_CONFIG.copy()
+    return {**DEFAULT_CONFIG, **data}
+
+
+def save_config(config):
+    CONFIG_DIR.mkdir(parents=True, exist_ok=True)
+    CONFIG_PATH.write_text(json.dumps(config, indent=2) + "\n")

--- a/frontend_gui.py
+++ b/frontend_gui.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+import queue
+import threading
+import tkinter as tk
+from tkinter import ttk, messagebox
+
+from frontend_config import load_config, save_config
+from frontend_service import (
+    get_service_status,
+    restart_service,
+    start_service,
+    stop_service,
+    tail_service_logs,
+)
+
+MODELS = ["tiny", "base", "small", "medium", "large-v3"]
+LANGUAGES = ["es", "en", "auto"]
+
+
+class WhisperFrontendApp:
+    def __init__(self, root):
+        self.root = root
+        self.root.title("whisper-ptt frontend")
+        self.root.geometry("760x560")
+        self.queue = queue.Queue()
+        self.config = load_config()
+        self.status_var = tk.StringVar(value="Cargando estado...")
+        self.mic_var = tk.StringVar(value="Micrófono: inactivo")
+        self.log_var = tk.StringVar(value="Cargando logs...")
+
+        self.key_var = tk.StringVar(value=self.config["key"])
+        self.toggle_var = tk.BooleanVar(value=self.config["toggle"])
+        self.language_var = tk.StringVar(value=self.config["language"])
+        self.model_var = tk.StringVar(value=self.config["model"])
+
+        self._build_ui()
+        self._refresh_async()
+        self._poll_queue()
+
+    def _build_ui(self):
+        header = ttk.Frame(self.root, padding=12)
+        header.pack(fill="x")
+
+        ttk.Label(header, text="whisper-ptt", font=("TkDefaultFont", 16, "bold")).pack(anchor="w")
+        ttk.Label(header, textvariable=self.status_var).pack(anchor="w", pady=(4, 0))
+        ttk.Label(header, textvariable=self.mic_var).pack(anchor="w")
+
+        notebook = ttk.Notebook(self.root)
+        notebook.pack(fill="both", expand=True, padx=12, pady=12)
+
+        status_tab = ttk.Frame(notebook, padding=12)
+        config_tab = ttk.Frame(notebook, padding=12)
+        logs_tab = ttk.Frame(notebook, padding=12)
+
+        notebook.add(status_tab, text="Estado")
+        notebook.add(config_tab, text="Configuración")
+        notebook.add(logs_tab, text="Logs")
+
+        self._build_status_tab(status_tab)
+        self._build_config_tab(config_tab)
+        self._build_logs_tab(logs_tab)
+
+    def _build_status_tab(self, parent):
+        actions = ttk.Frame(parent)
+        actions.pack(fill="x", pady=(0, 16))
+
+        ttk.Button(actions, text="Iniciar servicio", command=lambda: self._service_action(start_service)).pack(side="left", padx=(0, 8))
+        ttk.Button(actions, text="Detener servicio", command=lambda: self._service_action(stop_service)).pack(side="left", padx=(0, 8))
+        ttk.Button(actions, text="Reiniciar servicio", command=lambda: self._service_action(restart_service)).pack(side="left", padx=(0, 8))
+        ttk.Button(actions, text="Actualizar estado", command=self._refresh_async).pack(side="left")
+
+        summary = ttk.LabelFrame(parent, text="Configuración activa", padding=12)
+        summary.pack(fill="x")
+
+        self.summary_label = ttk.Label(summary, justify="left")
+        self.summary_label.pack(anchor="w")
+        self._update_summary()
+
+    def _build_config_tab(self, parent):
+        form = ttk.Frame(parent)
+        form.pack(fill="x")
+
+        ttk.Label(form, text="Tecla").grid(row=0, column=0, sticky="w", pady=6)
+        ttk.Entry(form, textvariable=self.key_var, width=20).grid(row=0, column=1, sticky="w", pady=6)
+
+        ttk.Label(form, text="Idioma").grid(row=1, column=0, sticky="w", pady=6)
+        ttk.Combobox(form, textvariable=self.language_var, values=LANGUAGES, state="readonly", width=17).grid(row=1, column=1, sticky="w", pady=6)
+
+        ttk.Label(form, text="Modelo").grid(row=2, column=0, sticky="w", pady=6)
+        ttk.Combobox(form, textvariable=self.model_var, values=MODELS, state="readonly", width=17).grid(row=2, column=1, sticky="w", pady=6)
+
+        ttk.Checkbutton(form, text="Modo toggle", variable=self.toggle_var).grid(row=3, column=0, columnspan=2, sticky="w", pady=6)
+
+        ttk.Button(form, text="Guardar configuración", command=self._save_config).grid(row=4, column=0, pady=(12, 0), sticky="w")
+
+    def _build_logs_tab(self, parent):
+        ttk.Button(parent, text="Recargar logs", command=self._refresh_async).pack(anchor="w", pady=(0, 8))
+        self.logs_text = tk.Text(parent, height=20, wrap="word")
+        self.logs_text.pack(fill="both", expand=True)
+        self.logs_text.insert("1.0", self.log_var.get())
+        self.logs_text.configure(state="disabled")
+
+    def _update_summary(self):
+        self.summary_label.config(
+            text=(
+                f"Tecla: {self.key_var.get().upper()}\n"
+                f"Idioma: {self.language_var.get()}\n"
+                f"Modelo: {self.model_var.get()}\n"
+                f"Modo toggle: {'sí' if self.toggle_var.get() else 'no'}"
+            )
+        )
+
+    def _save_config(self):
+        self.config = {
+            "key": self.key_var.get().strip().lower() or "f12",
+            "toggle": self.toggle_var.get(),
+            "language": self.language_var.get(),
+            "model": self.model_var.get(),
+        }
+        save_config(self.config)
+        self._update_summary()
+        self.mic_var.set("Micrófono: configuración guardada")
+        messagebox.showinfo("whisper-ptt", "Configuración guardada. Reinicia el servicio para aplicar cambios.")
+
+    def _service_action(self, action):
+        threading.Thread(target=self._run_service_action, args=(action,), daemon=True).start()
+
+    def _run_service_action(self, action):
+        result = action()
+        self.queue.put(("service_action", result.returncode, (result.stdout or result.stderr).strip()))
+        self.queue.put(("refresh", None, None))
+
+    def _refresh_async(self):
+        threading.Thread(target=self._load_runtime_state, daemon=True).start()
+
+    def _load_runtime_state(self):
+        status = get_service_status()
+        logs = tail_service_logs()
+        self.queue.put(("runtime", status, logs))
+
+    def _poll_queue(self):
+        try:
+            while True:
+                event, value, payload = self.queue.get_nowait()
+                if event == "runtime":
+                    self.status_var.set(f"Servicio: {value}")
+                    self.mic_var.set("Micrófono: listo" if value == "active" else "Micrófono: inactivo")
+                    self.logs_text.configure(state="normal")
+                    self.logs_text.delete("1.0", "end")
+                    self.logs_text.insert("1.0", payload or "Sin logs disponibles")
+                    self.logs_text.configure(state="disabled")
+                elif event == "service_action":
+                    if value == 0:
+                        self.status_var.set("Acción ejecutada correctamente")
+                    else:
+                        self.status_var.set("La acción del servicio devolvió error")
+                        if payload:
+                            self.mic_var.set(payload)
+                elif event == "refresh":
+                    self._refresh_async()
+        except queue.Empty:
+            pass
+        self.root.after(300, self._poll_queue)
+
+
+def main():
+    root = tk.Tk()
+    app = WhisperFrontendApp(root)
+    root.mainloop()
+
+
+if __name__ == "__main__":
+    main()

--- a/frontend_service.py
+++ b/frontend_service.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+import subprocess
+
+SERVICE_NAME = "whisper-dictation"
+
+
+def run_systemctl(*args):
+    return subprocess.run(
+        ["systemctl", "--user", *args, SERVICE_NAME],
+        capture_output=True,
+        text=True,
+    )
+
+
+def get_service_status():
+    result = run_systemctl("is-active")
+    status = (result.stdout or result.stderr).strip()
+    return status or "unknown"
+
+
+def start_service():
+    return run_systemctl("start")
+
+
+def stop_service():
+    return run_systemctl("stop")
+
+
+def restart_service():
+    return run_systemctl("restart")
+
+
+def tail_service_logs(lines=20):
+    result = subprocess.run(
+        ["journalctl", "--user", "-u", SERVICE_NAME, "-n", str(lines), "--no-pager"],
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip() or result.stderr.strip()

--- a/install.sh
+++ b/install.sh
@@ -2,68 +2,135 @@
 set -e
 
 # ── Colores ──────────────────────────────────────────────────────────────────
-RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'; NC='\033[0m'
+RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'; CYAN='\033[0;36m'; NC='\033[0m'
 info()    { echo -e "${GREEN}[✓]${NC} $1"; }
 warn()    { echo -e "${YELLOW}[!]${NC} $1"; }
 error()   { echo -e "${RED}[✗]${NC} $1"; exit 1; }
+step()    { echo -e "${CYAN}[→]${NC} $1"; }
 
-# ── Verificar que no se ejecute como root ─────────────────────────────────────
+# ── Verificar que no se ejecute como root ────────────────────────────────────
 [ "$EUID" -eq 0 ] && error "No ejecutar como root. Ejecuta como tu usuario normal."
+
+VENV_DIR="$HOME/.local/share/whisper-dictation"
+BIN_SCRIPT="$HOME/.local/bin/whisper-dictation.py"
+SERVICE_NAME="whisper-dictation"
+
+# ── Detectar modo: instalación nueva vs actualización ────────────────────────
+IS_UPDATE=false
+if [ -d "$VENV_DIR" ] && [ -f "$BIN_SCRIPT" ] && \
+   systemctl --user is-enabled "$SERVICE_NAME" &>/dev/null; then
+    IS_UPDATE=true
+fi
 
 echo ""
 echo "  whisper-ptt — Instalador"
 echo "  Push-to-talk dictation con Whisper offline"
 echo ""
 
-# ── Dependencias del sistema ──────────────────────────────────────────────────
-info "Verificando dependencias del sistema..."
+if $IS_UPDATE; then
+    echo -e "  ${CYAN}Modo: ACTUALIZACIÓN${NC} — instalación previa detectada"
+else
+    echo -e "  ${GREEN}Modo: INSTALACIÓN NUEVA${NC}"
+fi
+echo ""
+
+# ── Dependencias del sistema (ambos modos) ───────────────────────────────────
+step "Verificando dependencias del sistema..."
 MISSING=()
-command -v python3 &>/dev/null || MISSING+=("python3")
-command -v xdotool &>/dev/null || MISSING+=("xdotool")
-command -v xclip &>/dev/null   || MISSING+=("xclip")
+command -v python3  &>/dev/null || MISSING+=("python3")
+command -v xdotool  &>/dev/null || MISSING+=("xdotool")
+command -v xclip    &>/dev/null || MISSING+=("xclip")
 dpkg -l libportaudio2 &>/dev/null 2>&1 || MISSING+=("libportaudio2")
 
 if [ ${#MISSING[@]} -gt 0 ]; then
     warn "Instalando dependencias faltantes: ${MISSING[*]}"
     sudo apt-get install -y "${MISSING[@]}" portaudio19-dev
+else
+    info "Todas las dependencias del sistema están presentes."
 fi
 
-# ── Entorno virtual Python ────────────────────────────────────────────────────
-VENV_DIR="$HOME/.local/share/whisper-dictation"
-info "Creando entorno virtual en $VENV_DIR..."
-python3 -m venv "$VENV_DIR"
+# ── Flujo de ACTUALIZACIÓN ───────────────────────────────────────────────────
+if $IS_UPDATE; then
 
-info "Instalando librerías Python (puede tardar varios minutos)..."
-"$VENV_DIR/bin/pip" install --upgrade pip --quiet
-"$VENV_DIR/bin/pip" install faster-whisper sounddevice numpy pynput --quiet
+    step "Deteniendo servicio en ejecución..."
+    systemctl --user stop "$SERVICE_NAME"
+    info "Servicio detenido."
 
-# ── Copiar archivos ───────────────────────────────────────────────────────────
-info "Instalando archivos..."
-mkdir -p "$HOME/.local/bin"
-cp whisper-dictation.py "$HOME/.local/bin/whisper-dictation.py"
-cp dictate "$HOME/.local/bin/dictate"
-chmod +x "$HOME/.local/bin/dictate"
+    step "Actualizando archivos..."
+    # Mostrar qué cambió en el script principal
+    if ! diff -q whisper-dictation.py "$BIN_SCRIPT" &>/dev/null; then
+        info "whisper-dictation.py tiene cambios — actualizando."
+        cp whisper-dictation.py "$BIN_SCRIPT"
+    else
+        info "whisper-dictation.py sin cambios."
+    fi
 
-# ── Servicio systemd ──────────────────────────────────────────────────────────
-info "Configurando servicio systemd..."
-mkdir -p "$HOME/.config/systemd/user"
-cp whisper-dictation.service "$HOME/.config/systemd/user/whisper-dictation.service"
-systemctl --user daemon-reload
-systemctl --user enable whisper-dictation
-systemctl --user start whisper-dictation
+    if ! diff -q dictate "$HOME/.local/bin/dictate" &>/dev/null; then
+        info "dictate tiene cambios — actualizando."
+        cp dictate "$HOME/.local/bin/dictate"
+        chmod +x "$HOME/.local/bin/dictate"
+    else
+        info "dictate sin cambios."
+    fi
 
-# ── Verificar ~/.local/bin en PATH ───────────────────────────────────────────
-if [[ ":$PATH:" != *":$HOME/.local/bin:"* ]]; then
-    warn "~/.local/bin no está en tu PATH."
-    warn "Agrega esta línea a tu ~/.bashrc o ~/.zshrc:"
-    echo "    export PATH=\"\$HOME/.local/bin:\$PATH\""
+    SERVICE_FILE="$HOME/.config/systemd/user/$SERVICE_NAME.service"
+    if ! diff -q whisper-dictation.service "$SERVICE_FILE" &>/dev/null; then
+        info "Archivo de servicio tiene cambios — actualizando."
+        cp whisper-dictation.service "$SERVICE_FILE"
+        systemctl --user daemon-reload
+    else
+        info "Archivo de servicio sin cambios."
+    fi
+
+    step "Reiniciando servicio..."
+    systemctl --user start "$SERVICE_NAME"
+    info "Servicio reiniciado."
+
+# ── Flujo de INSTALACIÓN NUEVA ───────────────────────────────────────────────
+else
+
+    step "Creando entorno virtual Python en $VENV_DIR..."
+    python3 -m venv "$VENV_DIR"
+
+    step "Instalando librerías Python (puede tardar varios minutos)..."
+    "$VENV_DIR/bin/pip" install --upgrade pip --quiet
+    "$VENV_DIR/bin/pip" install faster-whisper sounddevice numpy pynput --quiet
+    info "Librerías Python instaladas."
+
+    step "Copiando archivos..."
+    mkdir -p "$HOME/.local/bin"
+    cp whisper-dictation.py "$BIN_SCRIPT"
+    cp dictate "$HOME/.local/bin/dictate"
+    chmod +x "$HOME/.local/bin/dictate"
+    info "Archivos copiados."
+
+    step "Configurando servicio systemd..."
+    mkdir -p "$HOME/.config/systemd/user"
+    cp whisper-dictation.service "$HOME/.config/systemd/user/$SERVICE_NAME.service"
+    systemctl --user daemon-reload
+    systemctl --user enable "$SERVICE_NAME"
+    systemctl --user start "$SERVICE_NAME"
+    info "Servicio habilitado e iniciado."
+
+    # ── Verificar ~/.local/bin en PATH ────────────────────────────────────────
+    if [[ ":$PATH:" != *":$HOME/.local/bin:"* ]]; then
+        warn "~/.local/bin no está en tu PATH."
+        warn "Agrega esta línea a tu ~/.bashrc o ~/.zshrc:"
+        echo "    export PATH=\"\$HOME/.local/bin:\$PATH\""
+    fi
+
 fi
 
+# ── Resumen final (ambos modos) ──────────────────────────────────────────────
 echo ""
-info "¡Instalación completada!"
+if $IS_UPDATE; then
+    info "¡Actualización completada!"
+else
+    info "¡Instalación completada!"
+fi
 echo ""
 echo "  Mantén presionada F12 para dictar."
 echo "  Usa 'dictate --download-all' para predescargar todos los modelos."
 echo "  Estado del servicio:"
-systemctl --user status whisper-dictation --no-pager -l || true
+systemctl --user status "$SERVICE_NAME" --no-pager -l || true
 echo ""

--- a/install.sh
+++ b/install.sh
@@ -20,6 +20,7 @@ info "Verificando dependencias del sistema..."
 MISSING=()
 command -v python3 &>/dev/null || MISSING+=("python3")
 command -v xdotool &>/dev/null || MISSING+=("xdotool")
+command -v xclip &>/dev/null   || MISSING+=("xclip")
 dpkg -l libportaudio2 &>/dev/null 2>&1 || MISSING+=("libportaudio2")
 
 if [ ${#MISSING[@]} -gt 0 ]; then
@@ -62,6 +63,7 @@ echo ""
 info "¡Instalación completada!"
 echo ""
 echo "  Mantén presionada F12 para dictar."
+echo "  Usa 'dictate --download-all' para predescargar todos los modelos."
 echo "  Estado del servicio:"
 systemctl --user status whisper-dictation --no-pager -l || true
 echo ""

--- a/install.sh
+++ b/install.sh
@@ -1,57 +1,74 @@
 #!/usr/bin/env bash
 set -e
 
-# ── Colores ──────────────────────────────────────────────────────────────────
 RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'; NC='\033[0m'
 info()    { echo -e "${GREEN}[✓]${NC} $1"; }
 warn()    { echo -e "${YELLOW}[!]${NC} $1"; }
 error()   { echo -e "${RED}[✗]${NC} $1"; exit 1; }
 
-# ── Verificar que no se ejecute como root ─────────────────────────────────────
 [ "$EUID" -eq 0 ] && error "No ejecutar como root. Ejecuta como tu usuario normal."
 
+APP_NAME="whisper-dictation"
+VENV_DIR="$HOME/.local/share/${APP_NAME}"
+LOCAL_BIN_DIR="$HOME/.local/bin"
+SYSTEMD_DIR="$HOME/.config/systemd/user"
+SERVICE_NAME="whisper-dictation.service"
+SERVICE_PATH="$SYSTEMD_DIR/$SERVICE_NAME"
+INSTALL_MODE="INSTALL"
+
+if [ -d "$VENV_DIR" ] || [ -f "$LOCAL_BIN_DIR/whisper-dictation.py" ] || [ -f "$SERVICE_PATH" ]; then
+    INSTALL_MODE="UPDATE"
+fi
+
 echo ""
-echo "  whisper-ptt — Instalador"
+echo "  whisper-ptt — ${INSTALL_MODE}"
 echo "  Push-to-talk dictation con Whisper offline"
 echo ""
 
-# ── Dependencias del sistema ──────────────────────────────────────────────────
 info "Verificando dependencias del sistema..."
-MISSING=()
-command -v python3 &>/dev/null || MISSING+=("python3")
-command -v xdotool &>/dev/null || MISSING+=("xdotool")
-dpkg -l libportaudio2 &>/dev/null 2>&1 || MISSING+=("libportaudio2")
+MISSING_PACKAGES=()
+command -v python3 &>/dev/null || MISSING_PACKAGES+=("python3")
+command -v xdotool &>/dev/null || MISSING_PACKAGES+=("xdotool")
+command -v xclip &>/dev/null || MISSING_PACKAGES+=("xclip")
+dpkg -s libportaudio2 &>/dev/null 2>&1 || MISSING_PACKAGES+=("libportaudio2")
+dpkg -s portaudio19-dev &>/dev/null 2>&1 || MISSING_PACKAGES+=("portaudio19-dev")
 
-if [ ${#MISSING[@]} -gt 0 ]; then
-    warn "Instalando dependencias faltantes: ${MISSING[*]}"
-    sudo apt-get install -y "${MISSING[@]}" portaudio19-dev
+if [ ${#MISSING_PACKAGES[@]} -gt 0 ]; then
+    warn "Instalando dependencias faltantes: ${MISSING_PACKAGES[*]}"
+    sudo apt-get update
+    sudo apt-get install -y "${MISSING_PACKAGES[@]}"
 fi
 
-# ── Entorno virtual Python ────────────────────────────────────────────────────
-VENV_DIR="$HOME/.local/share/whisper-dictation"
-info "Creando entorno virtual en $VENV_DIR..."
-python3 -m venv "$VENV_DIR"
+if systemctl --user is-active --quiet whisper-dictation; then
+    info "Deteniendo servicio actual antes de reemplazar archivos..."
+    systemctl --user stop whisper-dictation
+fi
+
+mkdir -p "$VENV_DIR"
+if [ ! -x "$VENV_DIR/bin/python3" ]; then
+    info "Creando entorno virtual en $VENV_DIR..."
+    python3 -m venv "$VENV_DIR"
+else
+    info "Reutilizando entorno virtual existente en $VENV_DIR..."
+fi
 
 info "Instalando librerías Python (puede tardar varios minutos)..."
 "$VENV_DIR/bin/pip" install --upgrade pip --quiet
 "$VENV_DIR/bin/pip" install faster-whisper sounddevice numpy pynput --quiet
 
-# ── Copiar archivos ───────────────────────────────────────────────────────────
 info "Instalando archivos..."
-mkdir -p "$HOME/.local/bin"
-cp whisper-dictation.py "$HOME/.local/bin/whisper-dictation.py"
-cp dictate "$HOME/.local/bin/dictate"
-chmod +x "$HOME/.local/bin/dictate"
+mkdir -p "$LOCAL_BIN_DIR"
+cp whisper-dictation.py "$LOCAL_BIN_DIR/whisper-dictation.py"
+cp dictate "$LOCAL_BIN_DIR/dictate"
+chmod +x "$LOCAL_BIN_DIR/dictate"
 
-# ── Servicio systemd ──────────────────────────────────────────────────────────
 info "Configurando servicio systemd..."
-mkdir -p "$HOME/.config/systemd/user"
-cp whisper-dictation.service "$HOME/.config/systemd/user/whisper-dictation.service"
+mkdir -p "$SYSTEMD_DIR"
+cp whisper-dictation.service "$SERVICE_PATH"
 systemctl --user daemon-reload
 systemctl --user enable whisper-dictation
-systemctl --user start whisper-dictation
+systemctl --user restart whisper-dictation
 
-# ── Verificar ~/.local/bin en PATH ───────────────────────────────────────────
 if [[ ":$PATH:" != *":$HOME/.local/bin:"* ]]; then
     warn "~/.local/bin no está en tu PATH."
     warn "Agrega esta línea a tu ~/.bashrc o ~/.zshrc:"
@@ -59,7 +76,7 @@ if [[ ":$PATH:" != *":$HOME/.local/bin:"* ]]; then
 fi
 
 echo ""
-info "¡Instalación completada!"
+info "¡${INSTALL_MODE} completado!"
 echo ""
 echo "  Mantén presionada F12 para dictar."
 echo "  Estado del servicio:"

--- a/install.sh
+++ b/install.sh
@@ -41,7 +41,11 @@ info "Instalando archivos..."
 mkdir -p "$HOME/.local/bin"
 cp whisper-dictation.py "$HOME/.local/bin/whisper-dictation.py"
 cp dictate "$HOME/.local/bin/dictate"
+cp frontend_gui.py "$HOME/.local/bin/whisper-ptt-gui"
+cp frontend_config.py "$HOME/.local/bin/frontend_config.py"
+cp frontend_service.py "$HOME/.local/bin/frontend_service.py"
 chmod +x "$HOME/.local/bin/dictate"
+chmod +x "$HOME/.local/bin/whisper-ptt-gui"
 
 # ── Servicio systemd ──────────────────────────────────────────────────────────
 info "Configurando servicio systemd..."

--- a/whisper-dictation.py
+++ b/whisper-dictation.py
@@ -38,8 +38,9 @@ INITIAL_PROMPT = (
     "JavaScript, TypeScript, React, Node, database, endpoint, repository."
 )
 
-# Directorio de caché de HuggingFace
-CACHE_DIR = os.path.expanduser("~/.cache/huggingface/hub")
+# Directorio de caché de HuggingFace — respeta XDG_CACHE_HOME (KDE usa ~/.cachekde)
+_xdg_cache = os.environ.get("XDG_CACHE_HOME", os.path.expanduser("~/.cache"))
+CACHE_DIR = os.path.join(_xdg_cache, "huggingface", "hub")
 # -----------------------------------------------
 
 # ---------- Registro de modelos ----------------

--- a/whisper-dictation.py
+++ b/whisper-dictation.py
@@ -4,13 +4,15 @@ Push-to-talk dictation para Linux X11 + KDE.
 Mantén presionada F12 para grabar. Al soltar, transcribe y escribe.
 
 Uso:
-  python3 whisper-dictation.py            # Tecla por defecto: F12
-  python3 whisper-dictation.py --key F10  # Cambiar tecla
-  python3 whisper-dictation.py --toggle   # Modo toggle
-  python3 whisper-dictation.py --model medium  # Modelo más preciso
+  python3 whisper-dictation.py                   # Modelo automático según RAM
+  python3 whisper-dictation.py --key F10         # Cambiar tecla
+  python3 whisper-dictation.py --toggle          # Modo toggle
+  python3 whisper-dictation.py --model medium    # Modelo específico
+  python3 whisper-dictation.py --download-all    # Predescargar todos los modelos
 """
 
 import argparse
+import os
 import subprocess
 import threading
 import time
@@ -21,11 +23,46 @@ from pynput import keyboard
 
 # ---------- Configuración por defecto ----------
 DEFAULT_KEY      = "f12"
-DEFAULT_MODEL    = "base"   # tiny | base | small | medium | large-v3
-DEFAULT_LANGUAGE = "es"     # None = autodetección
+DEFAULT_MODEL    = "auto"   # auto = mejor modelo según RAM disponible
+DEFAULT_LANGUAGE = "auto"   # auto = detección por segmento (soporta code-switching)
 SAMPLE_RATE      = 16000
 CHANNELS         = 1
+
+# Usado solo en modelos con quality <= 3 (tiny, base, small) que tienen capacidad
+# multilingüe limitada. En modelos medianos y grandes el code-switching funciona
+# nativamente y el prompt introduciría sesgo innecesario.
+INITIAL_PROMPT = (
+    "Transcripción en español con términos técnicos en inglés: "
+    "GitHub, issue, pull request, commit, branch, merge, API, Python, Linux, "
+    "deploy, bug, feature, terminal, script, model, token, pipeline, Docker, "
+    "JavaScript, TypeScript, React, Node, database, endpoint, repository."
+)
+
+# Directorio de caché de HuggingFace
+CACHE_DIR = os.path.expanduser("~/.cache/huggingface/hub")
 # -----------------------------------------------
+
+# ---------- Registro de modelos ----------------
+# Todos los modelos faster-whisper con requisitos de RAM y nivel de calidad.
+# Solo los multilingual=True son candidatos para auto-selección.
+MODEL_REGISTRY = {
+    "tiny":             {"ram_mb": 200,  "quality": 1, "multilingual": True},
+    "tiny.en":          {"ram_mb": 200,  "quality": 1, "multilingual": False},
+    "base":             {"ram_mb": 300,  "quality": 2, "multilingual": True},
+    "base.en":          {"ram_mb": 300,  "quality": 2, "multilingual": False},
+    "small":            {"ram_mb": 500,  "quality": 3, "multilingual": True},
+    "small.en":         {"ram_mb": 500,  "quality": 3, "multilingual": False},
+    "medium":           {"ram_mb": 1500, "quality": 4, "multilingual": True},
+    "medium.en":        {"ram_mb": 1500, "quality": 4, "multilingual": False},
+    "large-v1":         {"ram_mb": 3000, "quality": 5, "multilingual": True},
+    "large-v2":         {"ram_mb": 3000, "quality": 6, "multilingual": True},
+    "large-v3":         {"ram_mb": 3000, "quality": 7, "multilingual": True},
+    "distil-large-v3":  {"ram_mb": 1500, "quality": 6, "multilingual": True},
+    "distil-medium.en": {"ram_mb": 800,  "quality": 4, "multilingual": False},
+    "distil-small.en":  {"ram_mb": 400,  "quality": 3, "multilingual": False},
+}
+# -----------------------------------------------
+
 
 def notify(title, message, timeout=3):
     """Notificación visual en KDE (no bloqueante)."""
@@ -37,24 +74,81 @@ def notify(title, message, timeout=3):
             stderr=subprocess.DEVNULL,
         )
     except FileNotFoundError:
-        pass  # Si kdialog no está disponible, continúa sin notificación
+        pass
+
+
+def get_available_ram_mb():
+    """Lee la RAM disponible del sistema desde /proc/meminfo."""
+    try:
+        with open("/proc/meminfo") as f:
+            for line in f:
+                if line.startswith("MemAvailable"):
+                    return int(line.split()[1]) // 1024
+    except Exception:
+        pass
+    return 1000  # fallback conservador
+
+
+def auto_select_model():
+    """Elige el mejor modelo multilingüe que cabe en el 75% de la RAM disponible."""
+    available = get_available_ram_mb()
+    usable = available * 0.75
+    candidates = {
+        k: v for k, v in MODEL_REGISTRY.items()
+        if v["ram_mb"] <= usable and v["multilingual"]
+    }
+    if not candidates:
+        print("[Auto] RAM insuficiente para cualquier modelo, usando tiny.")
+        return "tiny"
+    best = max(candidates, key=lambda k: MODEL_REGISTRY[k]["quality"])
+    print(f"[Auto] RAM disponible: {available} MB → modelo seleccionado: '{best}'")
+    return best
+
+
+def is_model_cached(model_name):
+    """Verifica si el modelo ya está descargado en caché local."""
+    model_dir = os.path.join(CACHE_DIR, f"models--Systran--faster-whisper-{model_name}")
+    return os.path.isdir(model_dir)
+
+
+def download_all_models():
+    """Descarga todos los modelos del registry que no estén en caché."""
+    print("[⬇] Iniciando descarga de todos los modelos...")
+    notify("Whisper Dictation", "⬇️ Descargando todos los modelos...", 10)
+    for model_name in MODEL_REGISTRY:
+        if is_model_cached(model_name):
+            print(f"[✓] {model_name} — ya en caché, omitido.")
+            continue
+        print(f"[⬇] Descargando '{model_name}'...")
+        notify("Whisper Dictation", f"⬇️ Descargando {model_name}...", 30)
+        WhisperModel(model_name, device="cpu", compute_type="int8")
+        print(f"[✓] '{model_name}' descargado.")
+    print("[✓] Todos los modelos están disponibles.")
+    notify("Whisper Dictation", "✅ Todos los modelos descargados.", 5)
 
 
 class Dictation:
     def __init__(self, model_name, language, toggle_mode):
-        print(f"[Whisper Dictation] Cargando modelo '{model_name}'...")
-        notify("Whisper Dictation", "⏳ Cargando modelo, espera un momento...", 5)
+        if not is_model_cached(model_name):
+            print(f"[Whisper Dictation] Descargando modelo '{model_name}' (primera vez, puede tardar)...")
+            notify("Whisper Dictation", f"⬇️ Descargando modelo '{model_name}'...", 60)
+        else:
+            print(f"[Whisper Dictation] Cargando modelo '{model_name}'...")
+            notify("Whisper Dictation", "⏳ Cargando modelo, espera un momento...", 5)
+
         self.model = WhisperModel(
             model_name,
             device="cpu",
             compute_type="int8",
         )
+        self.model_name = model_name
         self.language = language
         self.toggle_mode = toggle_mode
         self.recording = False
         self.audio_frames = []
         self.lock = threading.Lock()
-        print(f"[Whisper Dictation] Listo. Idioma: {language or 'auto'}")
+        lang_display = language if language else "auto (multilingüe)"
+        print(f"[Whisper Dictation] Listo. Modelo: {model_name} | Idioma: {lang_display}")
         notify("Whisper Dictation", "✅ Listo — mantén F12 para dictar", 4)
 
     def start_recording(self):
@@ -100,12 +194,18 @@ class Dictation:
             notify("🎙 Dictado", "⚠️ Grabación muy corta, ignorada", 3)
             return
 
+        # INITIAL_PROMPT solo para modelos pequeños (quality <= 3)
+        model_quality = MODEL_REGISTRY.get(self.model_name, {}).get("quality", 4)
+        prompt = INITIAL_PROMPT if model_quality <= 3 else None
+
         segments, info = self.model.transcribe(
             audio,
             language=self.language,
             beam_size=5,
             vad_filter=True,
             vad_parameters=dict(min_silence_duration_ms=500),
+            initial_prompt=prompt,
+            temperature=0.0,
         )
 
         text = " ".join(seg.text for seg in segments).strip()
@@ -119,17 +219,83 @@ class Dictation:
             notify("🎙 Dictado", "⚠️ No se detectó habla", 3)
 
     def _type_text(self, text):
-        # Pausa para que F12 se suelte antes de escribir
+        """Escribe el texto usando la mejor herramienta disponible."""
         time.sleep(0.15)
+        if self._try_xclip(text):
+            return
+        if self._try_xsel(text):
+            return
+        self._fallback_xdotool(text)
+
+    def _try_xclip(self, text):
+        """Escribe vía xclip + Ctrl+V, guardando y restaurando el portapapeles."""
+        try:
+            prev = subprocess.run(
+                ["xclip", "-selection", "clipboard", "-o"],
+                capture_output=True,
+            )
+            subprocess.run(
+                ["xclip", "-selection", "clipboard"],
+                input=text.encode("utf-8"),
+                check=True,
+            )
+            subprocess.run(
+                ["xdotool", "key", "--clearmodifiers", "ctrl+v"],
+                check=True,
+            )
+            time.sleep(0.1)
+            if prev.returncode == 0:
+                subprocess.run(
+                    ["xclip", "-selection", "clipboard"],
+                    input=prev.stdout,
+                    check=False,
+                )
+            return True
+        except FileNotFoundError:
+            return False
+        except subprocess.CalledProcessError:
+            return False
+
+    def _try_xsel(self, text):
+        """Escribe vía xsel + Ctrl+V, guardando y restaurando el portapapeles."""
+        try:
+            prev = subprocess.run(
+                ["xsel", "--clipboard", "--output"],
+                capture_output=True,
+            )
+            subprocess.run(
+                ["xsel", "--clipboard", "--input"],
+                input=text.encode("utf-8"),
+                check=True,
+            )
+            subprocess.run(
+                ["xdotool", "key", "--clearmodifiers", "ctrl+v"],
+                check=True,
+            )
+            time.sleep(0.1)
+            if prev.returncode == 0:
+                subprocess.run(
+                    ["xsel", "--clipboard", "--input"],
+                    input=prev.stdout,
+                    check=False,
+                )
+            return True
+        except FileNotFoundError:
+            return False
+        except subprocess.CalledProcessError:
+            return False
+
+    def _fallback_xdotool(self, text):
+        """Último recurso: xdotool type. Puede perder tildes y caracteres especiales."""
+        print("[!] xclip y xsel no disponibles. Usando xdotool type (puede perder tildes).")
+        notify("⚠️ Dictado", "xclip/xsel no instalados — tildes pueden perderse", 5)
         try:
             subprocess.run(
                 ["xdotool", "type", "--clearmodifiers", "--delay", "0", "--", text],
                 check=True,
             )
-        except subprocess.CalledProcessError as e:
-            print(f"[Error xdotool] {e}")
-        except FileNotFoundError:
-            print("[Error] xdotool no encontrado. Instalar con: sudo apt install xdotool")
+        except (FileNotFoundError, subprocess.CalledProcessError) as e:
+            print(f"[Error] No se pudo escribir el texto: {e}")
 
 
 def main():
@@ -137,16 +303,24 @@ def main():
     parser.add_argument("--key", default=DEFAULT_KEY,
                         help=f"Tecla para activar (default: {DEFAULT_KEY})")
     parser.add_argument("--model", default=DEFAULT_MODEL,
-                        choices=["tiny", "base", "small", "medium", "large-v3"],
-                        help=f"Modelo Whisper (default: {DEFAULT_MODEL})")
+                        choices=["auto"] + list(MODEL_REGISTRY.keys()),
+                        help="Modelo Whisper a usar. 'auto' selecciona el mejor según RAM disponible.")
     parser.add_argument("--language", default=DEFAULT_LANGUAGE,
-                        help="Código de idioma ISO (es, en, fr...) o 'auto'")
+                        help="Código ISO del idioma (es, en, fr...) o 'auto' para detección multilingüe.")
     parser.add_argument("--toggle", action="store_true",
-                        help="Modo toggle: presionar una vez inicia, presionar de nuevo detiene")
+                        help="Modo toggle: presionar una vez inicia, presionar de nuevo detiene.")
+    parser.add_argument("--download-all", action="store_true",
+                        help="Descarga todos los modelos del registro y sale.")
     args = parser.parse_args()
 
+    if args.download_all:
+        download_all_models()
+        return
+
+    model_name = auto_select_model() if args.model == "auto" else args.model
     language = None if args.language == "auto" else args.language
-    dictation = Dictation(args.model, language, args.toggle)
+
+    dictation = Dictation(model_name, language, args.toggle)
 
     mode = "toggle" if args.toggle else "mantener presionada"
     print(f"[Whisper Dictation] Tecla activa: {args.key.upper()} ({mode})")
@@ -194,6 +368,7 @@ def main():
         except KeyboardInterrupt:
             print("\n[Whisper Dictation] Saliendo.")
             notify("Whisper Dictation", "🔴 Servicio detenido", 3)
+
 
 if __name__ == "__main__":
     main()

--- a/whisper-dictation.py
+++ b/whisper-dictation.py
@@ -2,59 +2,74 @@
 """
 Push-to-talk dictation para Linux X11 + KDE.
 Mantén presionada F12 para grabar. Al soltar, transcribe y escribe.
-
-Uso:
-  python3 whisper-dictation.py            # Tecla por defecto: F12
-  python3 whisper-dictation.py --key F10  # Cambiar tecla
-  python3 whisper-dictation.py --toggle   # Modo toggle
-  python3 whisper-dictation.py --model medium  # Modelo más preciso
 """
 
 import argparse
 import subprocess
 import threading
 import time
+from pathlib import Path
+
 import numpy as np
 import sounddevice as sd
 from faster_whisper import WhisperModel
 from pynput import keyboard
 
-# ---------- Configuración por defecto ----------
-DEFAULT_KEY      = "f12"
-DEFAULT_MODEL    = "base"   # tiny | base | small | medium | large-v3
-DEFAULT_LANGUAGE = "es"     # None = autodetección
-SAMPLE_RATE      = 16000
-CHANNELS         = 1
-# -----------------------------------------------
+DEFAULT_KEY = "f12"
+DEFAULT_MODEL = "base"
+DEFAULT_LANGUAGE = "es"
+SAMPLE_RATE = 16000
+CHANNELS = 1
+MODEL_REGISTRY = [
+    "tiny", "tiny.en",
+    "base", "base.en",
+    "small", "small.en",
+    "medium", "medium.en",
+    "large-v1", "large-v2", "large-v3", "large-v3-turbo",
+    "distil-small.en", "distil-medium.en", "distil-large-v2", "distil-large-v3",
+]
+MODEL_CACHE_DIR = Path.home() / ".cache" / "huggingface" / "hub"
+
 
 def notify(title, message, timeout=3):
-    """Notificación visual en KDE (no bloqueante)."""
     try:
         subprocess.Popen(
-            ["kdialog", "--passivepopup", f"{message}", str(timeout),
-             "--title", title],
+            ["kdialog", "--passivepopup", f"{message}", str(timeout), "--title", title],
             stdout=subprocess.DEVNULL,
             stderr=subprocess.DEVNULL,
         )
     except FileNotFoundError:
-        pass  # Si kdialog no está disponible, continúa sin notificación
+        pass
+
+
+def ensure_model_available(model_name, language):
+    notify("Whisper Dictation", f"⏳ Verificando modelo {model_name}...", 3)
+    if not any(model_name in p.name for p in MODEL_CACHE_DIR.glob("**/*")):
+        notify("Whisper Dictation", f"⬇️ Descargando modelo {model_name}...", 8)
+    compute_type = "int8"
+    if language == "auto" and not model_name.endswith(".en"):
+        compute_type = "int8"
+    return WhisperModel(model_name, device="cpu", compute_type=compute_type)
+
+
+def download_all_models():
+    for model_name in MODEL_REGISTRY:
+        print(f"[Whisper Dictation] Descargando {model_name}...")
+        ensure_model_available(model_name, None)
+    print("[Whisper Dictation] Todos los modelos registrados quedaron descargados.")
 
 
 class Dictation:
     def __init__(self, model_name, language, toggle_mode):
         print(f"[Whisper Dictation] Cargando modelo '{model_name}'...")
         notify("Whisper Dictation", "⏳ Cargando modelo, espera un momento...", 5)
-        self.model = WhisperModel(
-            model_name,
-            device="cpu",
-            compute_type="int8",
-        )
-        self.language = language
+        self.model = ensure_model_available(model_name, language)
+        self.language = None if language == "auto" else language
         self.toggle_mode = toggle_mode
         self.recording = False
         self.audio_frames = []
         self.lock = threading.Lock()
-        print(f"[Whisper Dictation] Listo. Idioma: {language or 'auto'}")
+        print(f"[Whisper Dictation] Listo. Idioma: {self.language or 'auto'}")
         notify("Whisper Dictation", "✅ Listo — mantén F12 para dictar", 4)
 
     def start_recording(self):
@@ -64,7 +79,7 @@ class Dictation:
             self.recording = True
             self.audio_frames = []
         print("[●] Grabando...", flush=True)
-        notify("🎙 Dictado", "Grabando... suelta F12 para transcribir", 30)
+        notify("🎙 Dictado", "Grabando... suelta la tecla para transcribir", 30)
         self._stream = sd.InputStream(
             samplerate=SAMPLE_RATE,
             channels=CHANNELS,
@@ -94,22 +109,21 @@ class Dictation:
             return
 
         audio = np.concatenate(self.audio_frames, axis=0).flatten()
-
         if len(audio) < SAMPLE_RATE * 0.5:
             print("[!] Grabación muy corta, ignorada.")
             notify("🎙 Dictado", "⚠️ Grabación muy corta, ignorada", 3)
             return
 
-        segments, info = self.model.transcribe(
+        segments, _ = self.model.transcribe(
             audio,
             language=self.language,
             beam_size=5,
             vad_filter=True,
             vad_parameters=dict(min_silence_duration_ms=500),
+            condition_on_previous_text=False,
         )
 
         text = " ".join(seg.text for seg in segments).strip()
-
         if text:
             print(f'[✓] "{text}"', flush=True)
             notify("✅ Transcripción", text, 5)
@@ -119,34 +133,35 @@ class Dictation:
             notify("🎙 Dictado", "⚠️ No se detectó habla", 3)
 
     def _type_text(self, text):
-        # Pausa para que F12 se suelte antes de escribir
         time.sleep(0.15)
-        try:
-            subprocess.run(
-                ["xdotool", "type", "--clearmodifiers", "--delay", "0", "--", text],
-                check=True,
-            )
-        except subprocess.CalledProcessError as e:
-            print(f"[Error xdotool] {e}")
-        except FileNotFoundError:
-            print("[Error] xdotool no encontrado. Instalar con: sudo apt install xdotool")
+        commands = [
+            ["xdotool", "type", "--clearmodifiers", "--delay", "0", "--", text],
+            ["bash", "-lc", f"printf %s {text!r} | xclip -selection clipboard && xdotool key --clearmodifiers ctrl+shift+v"],
+            ["bash", "-lc", f"printf %s {text!r} | xclip -selection clipboard && xdotool key --clearmodifiers ctrl+v"],
+        ]
+        for command in commands:
+            try:
+                subprocess.run(command, check=True)
+                return
+            except Exception:
+                continue
+        print("[Error] No se pudo escribir el texto con xdotool/xclip")
 
 
 def main():
     parser = argparse.ArgumentParser(description="Push-to-talk dictation con Whisper")
-    parser.add_argument("--key", default=DEFAULT_KEY,
-                        help=f"Tecla para activar (default: {DEFAULT_KEY})")
-    parser.add_argument("--model", default=DEFAULT_MODEL,
-                        choices=["tiny", "base", "small", "medium", "large-v3"],
-                        help=f"Modelo Whisper (default: {DEFAULT_MODEL})")
-    parser.add_argument("--language", default=DEFAULT_LANGUAGE,
-                        help="Código de idioma ISO (es, en, fr...) o 'auto'")
-    parser.add_argument("--toggle", action="store_true",
-                        help="Modo toggle: presionar una vez inicia, presionar de nuevo detiene")
+    parser.add_argument("--key", default=DEFAULT_KEY, help=f"Tecla para activar (default: {DEFAULT_KEY})")
+    parser.add_argument("--model", default=DEFAULT_MODEL, choices=MODEL_REGISTRY, help=f"Modelo Whisper (default: {DEFAULT_MODEL})")
+    parser.add_argument("--language", default=DEFAULT_LANGUAGE, help="Código de idioma ISO (es, en, fr...) o 'auto'")
+    parser.add_argument("--toggle", action="store_true", help="Modo toggle: presionar una vez inicia, presionar de nuevo detiene")
+    parser.add_argument("--download-all", action="store_true", help="Descarga previamente todos los modelos registrados")
     args = parser.parse_args()
 
-    language = None if args.language == "auto" else args.language
-    dictation = Dictation(args.model, language, args.toggle)
+    if args.download_all:
+        download_all_models()
+        return
+
+    dictation = Dictation(args.model, args.language, args.toggle)
 
     mode = "toggle" if args.toggle else "mantener presionada"
     print(f"[Whisper Dictation] Tecla activa: {args.key.upper()} ({mode})")
@@ -160,7 +175,6 @@ def main():
             key_name = key.name if hasattr(key, "name") else key.char
         except AttributeError:
             return
-
         if key_name == args.key.lower():
             if args.toggle:
                 if not pressed:
@@ -182,11 +196,9 @@ def main():
             key_name = key.name if hasattr(key, "name") else key.char
         except AttributeError:
             return
-
-        if key_name == args.key.lower():
-            if pressed:
-                pressed = False
-                threading.Thread(target=dictation.stop_and_transcribe, daemon=True).start()
+        if key_name == args.key.lower() and pressed:
+            pressed = False
+            threading.Thread(target=dictation.stop_and_transcribe, daemon=True).start()
 
     with keyboard.Listener(on_press=on_press, on_release=on_release) as listener:
         try:
@@ -194,6 +206,7 @@ def main():
         except KeyboardInterrupt:
             print("\n[Whisper Dictation] Saliendo.")
             notify("Whisper Dictation", "🔴 Servicio detenido", 3)
+
 
 if __name__ == "__main__":
     main()

--- a/whisper-dictation.py
+++ b/whisper-dictation.py
@@ -47,20 +47,21 @@ CACHE_DIR = os.path.join(_xdg_cache, "huggingface", "hub")
 # Todos los modelos faster-whisper con requisitos de RAM y nivel de calidad.
 # Solo los multilingual=True son candidatos para auto-selección.
 MODEL_REGISTRY = {
-    "tiny":             {"ram_mb": 200,  "quality": 1, "multilingual": True},
-    "tiny.en":          {"ram_mb": 200,  "quality": 1, "multilingual": False},
-    "base":             {"ram_mb": 300,  "quality": 2, "multilingual": True},
-    "base.en":          {"ram_mb": 300,  "quality": 2, "multilingual": False},
-    "small":            {"ram_mb": 500,  "quality": 3, "multilingual": True},
-    "small.en":         {"ram_mb": 500,  "quality": 3, "multilingual": False},
-    "medium":           {"ram_mb": 1500, "quality": 4, "multilingual": True},
-    "medium.en":        {"ram_mb": 1500, "quality": 4, "multilingual": False},
-    "large-v1":         {"ram_mb": 3000, "quality": 5, "multilingual": True},
-    "large-v2":         {"ram_mb": 3000, "quality": 6, "multilingual": True},
-    "large-v3":         {"ram_mb": 3000, "quality": 7, "multilingual": True},
-    "distil-large-v3":  {"ram_mb": 1500, "quality": 6, "multilingual": True},
-    "distil-medium.en": {"ram_mb": 800,  "quality": 4, "multilingual": False},
-    "distil-small.en":  {"ram_mb": 400,  "quality": 3, "multilingual": False},
+    # cpu_viable=False: modelos demasiado lentos en CPU puro (>60s por dictado)
+    "tiny":             {"ram_mb": 200,  "quality": 1, "multilingual": True,  "cpu_viable": True},
+    "tiny.en":          {"ram_mb": 200,  "quality": 1, "multilingual": False, "cpu_viable": True},
+    "base":             {"ram_mb": 300,  "quality": 2, "multilingual": True,  "cpu_viable": True},
+    "base.en":          {"ram_mb": 300,  "quality": 2, "multilingual": False, "cpu_viable": True},
+    "small":            {"ram_mb": 500,  "quality": 3, "multilingual": True,  "cpu_viable": True},
+    "small.en":         {"ram_mb": 500,  "quality": 3, "multilingual": False, "cpu_viable": True},
+    "medium":           {"ram_mb": 1500, "quality": 4, "multilingual": True,  "cpu_viable": True},
+    "medium.en":        {"ram_mb": 1500, "quality": 4, "multilingual": False, "cpu_viable": True},
+    "large-v1":         {"ram_mb": 3000, "quality": 5, "multilingual": True,  "cpu_viable": False},
+    "large-v2":         {"ram_mb": 3000, "quality": 6, "multilingual": True,  "cpu_viable": False},
+    "large-v3":         {"ram_mb": 3000, "quality": 7, "multilingual": True,  "cpu_viable": False},
+    "distil-large-v3":  {"ram_mb": 1500, "quality": 6, "multilingual": True,  "cpu_viable": True},
+    "distil-medium.en": {"ram_mb": 800,  "quality": 4, "multilingual": False, "cpu_viable": True},
+    "distil-small.en":  {"ram_mb": 400,  "quality": 3, "multilingual": False, "cpu_viable": True},
 }
 # -----------------------------------------------
 
@@ -91,12 +92,12 @@ def get_available_ram_mb():
 
 
 def auto_select_model():
-    """Elige el mejor modelo multilingüe que cabe en el 75% de la RAM disponible."""
+    """Elige el mejor modelo multilingüe y viable en CPU según RAM disponible."""
     available = get_available_ram_mb()
     usable = available * 0.75
     candidates = {
         k: v for k, v in MODEL_REGISTRY.items()
-        if v["ram_mb"] <= usable and v["multilingual"]
+        if v["ram_mb"] <= usable and v["multilingual"] and v["cpu_viable"]
     }
     if not candidates:
         print("[Auto] RAM insuficiente para cualquier modelo, usando tiny.")

--- a/whisper-dictation.service
+++ b/whisper-dictation.service
@@ -9,6 +9,7 @@ ExecStart=%h/.local/bin/dictate
 Restart=on-failure
 RestartSec=5
 Environment=DISPLAY=:0
+Environment=XAUTHORITY=%h/.Xauthority
 StandardOutput=journal
 StandardError=journal
 


### PR DESCRIPTION
## Qué se hizo
- agrega propuesta formal de frontend gráfico para configurar y operar `whisper-ptt`
- documenta principios, alcance, pantallas, flujos y roadmap de implementación
- enlaza la propuesta desde el README
- considera la evolución ya visible en `feat/mejoras-generales` para no duplicar trabajo

## Archivos agregados
- `docs/frontend/FRONTEND-PROPOSAL.md`
- `docs/frontend/UI-FLOWS.md`
- `docs/frontend/IMPLEMENTATION-PLAN.md`

## Por qué
Resuelve el issue #6 con una propuesta sólida y utilizable para orientar una futura implementación incremental del frontend, manteniendo coherencia con la filosofía simple/offline del proyecto.

Closes #6