### PR TITLE
feat: add dictate --status diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,9 +72,22 @@ systemctl --user stop whisper-dictation
 journalctl --user -u whisper-dictation -f
 ```
 
+### Diagnóstico rápido
+```bash
+dictate --status
+dictate --status --json
+```
+
+`dictate --status` consolida en una sola salida el estado del servicio systemd,
+la sesión gráfica, modelo configurado/cacheado, idioma, tecla, modo, backend de
+audio, backend de escritura, uso de caché y el último error del journal de las
+últimas 24 horas. Usa `--json` para integrar el diagnóstico con herramientas o
+la GUI.
+
 ### Validaciones rápidas
 ```bash
 which dictate
+dictate --status
 systemctl --user status whisper-dictation
 journalctl --user -u whisper-dictation -n 50 --no-pager
 ```

--- a/whisper-dictation.py
+++ b/whisper-dictation.py
@@ -259,6 +259,8 @@ def _get_last_journal_error():
     )
     if result is None:
         return {"available": False, "message": "journalctl not found"}
+    if result.returncode == 124:
+        return {"available": False, "message": None}
     output = (result.stdout or result.stderr or "").strip()
     if not output or "-- No entries --" in output:
         return {"available": True, "message": None}
@@ -270,7 +272,7 @@ def _get_last_activity():
         ["journalctl", "--user", "-u", SERVICE_NAME, "-n", "1", "--no-pager", "--output", "short-iso"],
         timeout=0.8,
     )
-    if result is None:
+    if result is None or result.returncode == 124:
         return None
     output = (result.stdout or "").strip()
     if not output or "-- No entries --" in output:
@@ -512,6 +514,7 @@ def main():
     model_name = auto_select_model() if args.model == "auto" else args.model
     language = None if args.language == "auto" else args.language
 
+    global sd, keyboard
     import sounddevice as sd
     from pynput import keyboard
 

--- a/whisper-dictation.py
+++ b/whisper-dictation.py
@@ -12,20 +12,19 @@ Uso:
 """
 
 import argparse
+import json
 import os
+import shutil
 import subprocess
 import threading
 import time
-
-import numpy as np
-import sounddevice as sd
-from faster_whisper import WhisperModel
-from pynput import keyboard
 
 # ---------- Configuración por defecto ----------
 DEFAULT_KEY = "f12"
 DEFAULT_MODEL = "auto"
 DEFAULT_LANGUAGE = "auto"
+SERVICE_NAME = "whisper-dictation"
+CONFIG_PATH = os.path.expanduser("~/.config/whisper-dictation/config.json")
 SAMPLE_RATE = 16000
 CHANNELS = 1
 
@@ -82,7 +81,7 @@ def get_available_ram_mb():
     return 1000
 
 
-def auto_select_model():
+def auto_select_model(quiet=False):
     available = get_available_ram_mb()
     usable = available * 0.75
     candidates = {
@@ -90,10 +89,12 @@ def auto_select_model():
         if v["ram_mb"] <= usable and v["multilingual"] and v["cpu_viable"]
     }
     if not candidates:
-        print("[Auto] RAM insuficiente para cualquier modelo, usando tiny.")
+        if not quiet:
+            print("[Auto] RAM insuficiente para cualquier modelo, usando tiny.")
         return "tiny"
     best = max(candidates, key=lambda k: MODEL_REGISTRY[k]["quality"])
-    print(f"[Auto] RAM disponible: {available} MB → modelo seleccionado: '{best}'")
+    if not quiet:
+        print(f"[Auto] RAM disponible: {available} MB → modelo seleccionado: '{best}'")
     return best
 
 
@@ -103,6 +104,8 @@ def is_model_cached(model_name):
 
 
 def ensure_model_available(model_name):
+    from faster_whisper import WhisperModel
+
     if not is_model_cached(model_name):
         print(f"[Whisper Dictation] Descargando modelo '{model_name}' (primera vez, puede tardar)...")
         notify("Whisper Dictation", f"⬇️ Descargando modelo '{model_name}'...", 60)
@@ -113,6 +116,8 @@ def ensure_model_available(model_name):
 
 
 def download_all_models():
+    from faster_whisper import WhisperModel
+
     print("[⬇] Iniciando descarga de todos los modelos...")
     notify("Whisper Dictation", "⬇️ Descargando todos los modelos...", 10)
     for model_name in MODEL_REGISTRY:
@@ -125,6 +130,227 @@ def download_all_models():
         print(f"[✓] '{model_name}' descargado.")
     print("[✓] Todos los modelos están disponibles.")
     notify("Whisper Dictation", "✅ Todos los modelos descargados.", 5)
+
+
+def _run_command(command, timeout=0.8):
+    try:
+        return subprocess.run(
+            command,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            check=False,
+        )
+    except FileNotFoundError:
+        return None
+    except subprocess.TimeoutExpired as exc:
+        completed = subprocess.CompletedProcess(command, 124, exc.stdout or "", exc.stderr or "timeout")
+        return completed
+
+
+def _command_output(command, timeout=0.8):
+    result = _run_command(command, timeout=timeout)
+    if result is None:
+        return None
+    return (result.stdout or result.stderr or "").strip()
+
+
+def _load_status_config():
+    config = {
+        "key": DEFAULT_KEY,
+        "toggle": False,
+        "language": DEFAULT_LANGUAGE,
+        "model": DEFAULT_MODEL,
+    }
+    try:
+        with open(CONFIG_PATH, encoding="utf-8") as f:
+            data = json.load(f)
+        if isinstance(data, dict):
+            config.update({k: data[k] for k in config if k in data})
+    except (OSError, json.JSONDecodeError):
+        pass
+    return config
+
+
+def _get_service_status():
+    result = _run_command(
+        ["systemctl", "--user", "show", SERVICE_NAME, "--property=ActiveState,SubState,MainPID", "--value"],
+        timeout=0.8,
+    )
+    if result is None:
+        return {"available": False, "state": "unknown", "substate": "systemctl not found", "pid": None}
+    values = (result.stdout or "").splitlines()
+    state = values[0].strip() if len(values) > 0 and values[0].strip() else "unknown"
+    substate = values[1].strip() if len(values) > 1 and values[1].strip() else "unknown"
+    pid_raw = values[2].strip() if len(values) > 2 else "0"
+    try:
+        pid = int(pid_raw)
+    except ValueError:
+        pid = 0
+    return {"available": result.returncode == 0, "state": state, "substate": substate, "pid": pid or None}
+
+
+def _get_session_type():
+    session = os.environ.get("XDG_SESSION_TYPE")
+    if session:
+        return session.upper()
+    if os.environ.get("WAYLAND_DISPLAY"):
+        return "Wayland"
+    if os.environ.get("DISPLAY"):
+        return "X11"
+    return "unknown"
+
+
+def _get_typing_backend():
+    version = _command_output(["xdotool", "--version"], timeout=0.5)
+    xclip = shutil.which("xclip") is not None
+    xsel = shutil.which("xsel") is not None
+    if version:
+        backend = "clipboard+xdotool" if xclip or xsel else "xdotool"
+        return {"ok": True, "backend": backend, "xdotool": version, "xclip": xclip, "xsel": xsel}
+    return {"ok": False, "backend": "missing", "xdotool": None, "xclip": xclip, "xsel": xsel}
+
+
+def _get_audio_backend():
+    pactl = _command_output(["pactl", "info"], timeout=0.8)
+    if pactl:
+        server = "unknown"
+        sink = "unknown"
+        source = "unknown"
+        for line in pactl.splitlines():
+            if line.startswith("Server Name:"):
+                server = line.split(":", 1)[1].strip()
+            elif line.startswith("Default Sink:"):
+                sink = line.split(":", 1)[1].strip()
+            elif line.startswith("Default Source:"):
+                source = line.split(":", 1)[1].strip()
+        return {"ok": True, "backend": "pulseaudio", "server": server, "default_sink": sink, "default_source": source}
+    if shutil.which("pipewire"):
+        return {"ok": True, "backend": "pipewire", "server": "pipewire", "default_sink": "unknown", "default_source": "unknown"}
+    return {"ok": False, "backend": "missing", "server": None, "default_sink": None, "default_source": None}
+
+
+def _get_cache_usage(path):
+    if not os.path.exists(path):
+        return 0
+    total = 0
+    for root, _, files in os.walk(path):
+        for filename in files:
+            try:
+                total += os.path.getsize(os.path.join(root, filename))
+            except OSError:
+                pass
+    return total
+
+
+def _format_bytes(size):
+    value = float(size)
+    for unit in ("B", "KB", "MB", "GB"):
+        if value < 1024 or unit == "GB":
+            return f"{value:.0f}{unit}" if unit == "B" else f"{value:.1f}{unit}"
+        value /= 1024
+    return f"{value:.1f}GB"
+
+
+def _get_last_journal_error():
+    result = _run_command(
+        ["journalctl", "--user", "-u", SERVICE_NAME, "--since", "24 hours ago", "-p", "err", "-n", "1", "--no-pager", "--output", "short-iso"],
+        timeout=0.8,
+    )
+    if result is None:
+        return {"available": False, "message": "journalctl not found"}
+    output = (result.stdout or result.stderr or "").strip()
+    if not output or "-- No entries --" in output:
+        return {"available": True, "message": None}
+    return {"available": True, "message": output.splitlines()[-1]}
+
+
+def _get_last_activity():
+    result = _run_command(
+        ["journalctl", "--user", "-u", SERVICE_NAME, "-n", "1", "--no-pager", "--output", "short-iso"],
+        timeout=0.8,
+    )
+    if result is None:
+        return None
+    output = (result.stdout or "").strip()
+    if not output or "-- No entries --" in output:
+        return None
+    return output.splitlines()[-1]
+
+
+def collect_status(cli_model=DEFAULT_MODEL):
+    config = _load_status_config()
+    configured_model = config.get("model") or cli_model or DEFAULT_MODEL
+    if configured_model == "auto":
+        model_name = auto_select_model(quiet=True)
+    else:
+        model_name = configured_model
+    model_cache_dir = os.path.join(CACHE_DIR, f"models--Systran--faster-whisper-{model_name}")
+    cache_bytes = _get_cache_usage(model_cache_dir)
+    return {
+        "service": _get_service_status(),
+        "session_type": _get_session_type(),
+        "model": {
+            "configured": configured_model,
+            "resolved": model_name,
+            "cached": is_model_cached(model_name),
+            "cache_path": model_cache_dir,
+            "cache_bytes": cache_bytes,
+            "cache_size": _format_bytes(cache_bytes),
+        },
+        "language": config.get("language", DEFAULT_LANGUAGE),
+        "key_binding": str(config.get("key", DEFAULT_KEY)).upper(),
+        "mode": "toggle" if config.get("toggle") else "hold",
+        "audio_backend": _get_audio_backend(),
+        "typing_backend": _get_typing_backend(),
+        "dependencies": {
+            "systemctl": shutil.which("systemctl") is not None,
+            "journalctl": shutil.which("journalctl") is not None,
+            "xdotool": shutil.which("xdotool") is not None,
+            "xclip": shutil.which("xclip") is not None,
+            "xsel": shutil.which("xsel") is not None,
+            "pactl": shutil.which("pactl") is not None,
+            "pipewire": shutil.which("pipewire") is not None,
+        },
+        "last_error": _get_last_journal_error(),
+        "last_activity": _get_last_activity(),
+    }
+
+
+def _ok(value):
+    return "✅" if value else "❌"
+
+
+def print_status(report, json_output=False):
+    if json_output:
+        print(json.dumps(report, indent=2, ensure_ascii=False))
+        return
+
+    service = report["service"]
+    model = report["model"]
+    audio = report["audio_backend"]
+    typing = report["typing_backend"]
+    last_error = report["last_error"].get("message") or "none"
+    pid = f" PID {service['pid']}" if service.get("pid") else ""
+    model_cache = f"cached at {model['cache_path']}" if model["cached"] else "not cached"
+    audio_device = audio.get("default_source") or audio.get("default_sink") or "unknown"
+
+    print("whisper-ptt status")
+    print("=====================================")
+    print(f"service:        {service['state']} ({service['substate']}){pid}")
+    print(f"session type:   {report['session_type']}")
+    print(f"model:          {model['resolved']} ({model_cache})")
+    print(f"language:       {report['language']}")
+    print(f"key binding:    {report['key_binding']} ({report['mode']})")
+    print(f"mode:           {report['mode']}")
+    print(f"audio backend:  {_ok(audio['ok'])} {audio['backend']} (default device: {audio_device})")
+    print(f"xdotool:        {_ok(typing['ok'])} {typing['xdotool'] or 'missing'}")
+    print(f"typing backend: {typing['backend']}")
+    print(f"disk usage:     model cache {model['cache_size']}")
+    print(f"last error:     {last_error}")
+    print(f"last activity:  {report['last_activity'] or 'none'}")
+    missing = [name for name, present in report["dependencies"].items() if not present]
+    print(f"dependencies:   {'ok' if not missing else 'missing ' + ', '.join(missing)}")
 
 
 class Dictation:
@@ -162,6 +388,8 @@ class Dictation:
                 self.audio_frames.append(indata.copy())
 
     def stop_and_transcribe(self):
+        import numpy as np
+
         with self.lock:
             if not self.recording:
                 return
@@ -266,7 +494,16 @@ def main():
                         help="Modo toggle: presionar una vez inicia, presionar de nuevo detiene.")
     parser.add_argument("--download-all", action="store_true",
                         help="Descarga todos los modelos del registro y sale.")
+    parser.add_argument("--status", action="store_true",
+                        help="Muestra diagnóstico del servicio, modelo, sesión, audio, xdotool y último error del journal.")
+    parser.add_argument("--json", action="store_true",
+                        help="Con --status, emite el diagnóstico en JSON parseable.")
     args = parser.parse_args()
+
+    if args.status:
+        report = collect_status(args.model)
+        print_status(report, json_output=args.json)
+        return
 
     if args.download_all:
         download_all_models()
@@ -274,6 +511,10 @@ def main():
 
     model_name = auto_select_model() if args.model == "auto" else args.model
     language = None if args.language == "auto" else args.language
+
+    import sounddevice as sd
+    from pynput import keyboard
+
     dictation = Dictation(model_name, language, args.toggle)
 
     mode = "toggle" if args.toggle else "mantener presionada"


### PR DESCRIPTION
## Summary
- add `dictate --status` diagnostic command
- include service state, model config/cache, session type, active audio device, xdotool status, and last journal error
- add `--json` output for parseable status
- update README with status usage

## Testing
- `python3 -m py_compile whisper-dictation.py`
- `python3 whisper-dictation.py --help`
- `python3 whisper-dictation.py --status`
- `python3 whisper-dictation.py --status --json`