### PR TITLE
test: add pytest suite and CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,57 @@
+name: CI
+
+on:
+  push:
+    branches: [dev, main, master]
+  pull_request:
+    branches: [dev]
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install linters
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install ruff
+          sudo apt-get update
+          sudo apt-get install -y shellcheck
+
+      - name: Ruff
+        run: ruff check .
+
+      - name: ShellCheck
+        run: shellcheck install.sh dictate
+
+  test:
+    name: Pytest Python ${{ matrix.python-version }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12"]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install test dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install pytest
+
+      - name: Run tests
+        run: pytest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,9 @@
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+
+[tool.ruff]
+line-length = 120
+exclude = [".git", "__pycache__", ".venv", "venv"]
+
+[tool.ruff.lint]
+select = ["E", "F", "I"]

--- a/tests/test_arg_parsing.py
+++ b/tests/test_arg_parsing.py
@@ -1,0 +1,98 @@
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+
+def load_dictation_module(monkeypatch):
+    monkeypatch.setitem(sys.modules, "numpy", types.SimpleNamespace(concatenate=lambda frames, axis=0: frames))
+    monkeypatch.setitem(sys.modules, "sounddevice", types.SimpleNamespace(InputStream=object))
+    monkeypatch.setitem(
+        sys.modules,
+        "faster_whisper",
+        types.SimpleNamespace(WhisperModel=lambda *args, **kwargs: object()),
+    )
+    keyboard_stub = types.SimpleNamespace(Listener=object)
+    monkeypatch.setitem(sys.modules, "pynput", types.SimpleNamespace(keyboard=keyboard_stub))
+    monkeypatch.setitem(sys.modules, "pynput.keyboard", keyboard_stub)
+
+    module_path = Path(__file__).resolve().parents[1] / "whisper-dictation.py"
+    spec = importlib.util.spec_from_file_location("whisper_dictation", module_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class ListenerStub:
+    def __init__(self, on_press=None, on_release=None):
+        self.on_press = on_press
+        self.on_release = on_release
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def join(self):
+        return None
+
+
+def test_download_all_flag_exits_before_starting_listener(monkeypatch):
+    module = load_dictation_module(monkeypatch)
+    called = {"download_all": False}
+
+    def fake_download_all_models():
+        called["download_all"] = True
+
+    monkeypatch.setattr(module, "download_all_models", fake_download_all_models)
+    monkeypatch.setattr(sys, "argv", ["whisper-dictation.py", "--download-all"])
+
+    module.main()
+
+    assert called["download_all"] is True
+
+
+def test_main_parses_key_model_language_and_toggle(monkeypatch):
+    module = load_dictation_module(monkeypatch)
+    created = {}
+
+    class DictationStub:
+        def __init__(self, model_name, language, toggle_mode):
+            created.update(model_name=model_name, language=language, toggle_mode=toggle_mode)
+
+        def start_recording(self):
+            raise AssertionError("listener should not invoke recording during argument parsing")
+
+        def stop_and_transcribe(self):
+            raise AssertionError("listener should not invoke transcription during argument parsing")
+
+    monkeypatch.setattr(module, "Dictation", DictationStub)
+    monkeypatch.setattr(module.keyboard, "Listener", ListenerStub)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["whisper-dictation.py", "--key", "F10", "--model", "small", "--language", "auto", "--toggle"],
+    )
+
+    module.main()
+
+    assert created == {"model_name": "small", "language": None, "toggle_mode": True}
+
+
+def test_auto_model_is_resolved_before_dictation_is_created(monkeypatch):
+    module = load_dictation_module(monkeypatch)
+    created = {}
+
+    class DictationStub:
+        def __init__(self, model_name, language, toggle_mode):
+            created["model_name"] = model_name
+
+    monkeypatch.setattr(module, "auto_select_model", lambda: "distil-large-v3")
+    monkeypatch.setattr(module, "Dictation", DictationStub)
+    monkeypatch.setattr(module.keyboard, "Listener", ListenerStub)
+    monkeypatch.setattr(sys, "argv", ["whisper-dictation.py", "--model", "auto"])
+
+    module.main()
+
+    assert created["model_name"] == "distil-large-v3"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,40 @@
+import importlib
+
+
+def config_module(monkeypatch, tmp_path):
+    module = importlib.import_module("frontend_config")
+    monkeypatch.setattr(module, "CONFIG_DIR", tmp_path / "whisper-dictation")
+    monkeypatch.setattr(module, "CONFIG_PATH", tmp_path / "whisper-dictation" / "config.json")
+    return module
+
+
+def test_load_config_returns_defaults_when_file_is_missing(monkeypatch, tmp_path):
+    module = config_module(monkeypatch, tmp_path)
+
+    assert module.load_config() == module.DEFAULT_CONFIG
+
+
+def test_save_config_creates_parent_directory_and_round_trips(monkeypatch, tmp_path):
+    module = config_module(monkeypatch, tmp_path)
+    config = {"key": "f10", "toggle": True, "language": "auto", "model": "small"}
+
+    module.save_config(config)
+
+    assert module.CONFIG_PATH.exists()
+    assert module.load_config() == config
+
+
+def test_load_config_merges_partial_config_with_defaults(monkeypatch, tmp_path):
+    module = config_module(monkeypatch, tmp_path)
+    module.CONFIG_DIR.mkdir(parents=True)
+    module.CONFIG_PATH.write_text('{"key": "f9"}\n')
+
+    assert module.load_config() == {**module.DEFAULT_CONFIG, "key": "f9"}
+
+
+def test_load_config_falls_back_to_defaults_for_invalid_json(monkeypatch, tmp_path):
+    module = config_module(monkeypatch, tmp_path)
+    module.CONFIG_DIR.mkdir(parents=True)
+    module.CONFIG_PATH.write_text("not-json")
+
+    assert module.load_config() == module.DEFAULT_CONFIG

--- a/tests/test_install_preflight.py
+++ b/tests/test_install_preflight.py
@@ -1,0 +1,67 @@
+import subprocess
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+INSTALL_SH = REPO_ROOT / "install.sh"
+
+
+def preflight_definition():
+    text = INSTALL_SH.read_text()
+    marker = "\npreflight_check\n"
+    assert marker in text
+    return text.split(marker, 1)[0]
+
+
+def run_preflight_with_stubs(command_stub):
+    script = f"""
+{preflight_definition()}
+{command_stub}
+preflight_check
+"""
+    return subprocess.run(["bash", "-c", script], capture_output=True, text=True)
+
+
+def test_preflight_succeeds_when_required_commands_are_available():
+    result = run_preflight_with_stubs(
+        r'''
+command() {
+  if [ "$1" = "-v" ]; then
+    case "$2" in
+      python3|pip3|pkg-config|xdotool|pactl) return 0 ;;
+      *) return 1 ;;
+    esac
+  fi
+  builtin command "$@"
+}
+python3() { return 0; }
+pkg-config() { return 0; }
+'''
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "Preflight OK" in result.stdout
+
+
+def test_preflight_reports_missing_xdotool_with_install_hint():
+    result = run_preflight_with_stubs(
+        r'''
+command() {
+  if [ "$1" = "-v" ]; then
+    case "$2" in
+      python3|pip3|pkg-config|pactl) return 0 ;;
+      xdotool) return 1 ;;
+      *) return 1 ;;
+    esac
+  fi
+  builtin command "$@"
+}
+python3() { return 0; }
+pkg-config() { return 0; }
+'''
+    )
+
+    assert result.returncode == 1
+    assert "xdotool" in result.stdout
+    assert "Instala con:" in result.stdout
+    assert "Preflight falló" in result.stdout


### PR DESCRIPTION
## Summary
- Add pytest coverage for argument parsing, frontend config persistence, and install preflight behavior.
- Add GitHub Actions CI with ruff + shellcheck lint job and pytest matrix for Python 3.10, 3.11, and 3.12.
- Add pyproject.toml with pytest and ruff configuration.

## Checks
- 988a5ee test: add pytest suite and CI workflow passed.
-  could not run locally because pytest is not installed in the runner environment.

Closes #13