### PR TITLE
feat: configurable STT provider with Groq Whisper support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Install test dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install pytest
+          python -m pip install pytest numpy
 
       - name: Run tests
         run: pytest

--- a/README.md
+++ b/README.md
@@ -1,12 +1,13 @@
 # whisper-ptt
 
-Push-to-talk dictation para Linux usando OpenAI Whisper offline.
-Mantén presionada una tecla para grabar tu voz y el texto se escribe
-automáticamente donde tengas el cursor. Sin internet, sin APIs, funciona
-en cualquier aplicación.
+Push-to-talk dictation para Linux usando OpenAI Whisper offline por defecto,
+con opción configurable para usar una API STT alternativa. Mantén presionada
+una tecla para grabar tu voz y el texto se escribe automáticamente donde
+tengas el cursor. En modo local funciona sin internet ni APIs; en modo API
+requiere configurar credenciales explícitas.
 
 ## Características
-- 100% offline — tu voz nunca sale de tu máquina
+- Offline por defecto — tu voz no sale de tu máquina salvo que actives un proveedor API
 - Funciona en cualquier aplicación (navegador, editor, terminal, etc.)
 - Notificaciones visuales en KDE
 - Arranque automático al iniciar sesión (systemd)
@@ -119,6 +120,9 @@ MIT
 
 ## STT alternativo: Groq API
 Además del modo local offline, puedes usar Groq como backend de transcripción.
+Groq se integra mediante su endpoint compatible con OpenAI Whisper y permite
+probar modelos hosted sin cambiar el flujo push-to-talk. Mantén `local` como
+proveedor si necesitas máxima privacidad/offline.
 
 Variables de entorno:
 - `GROQ_API_KEY` (requerida cuando `--stt-provider groq`)

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ dictate --model distil-large-v3  # Variante distil-whisper
 dictate --language auto          # Detectar idioma automáticamente
 dictate --toggle                 # Modo toggle en vez de mantener presionado
 dictate --download-all           # Pre-descarga todos los modelos registrados
+dictate --stt-provider groq       # Usa Groq Whisper API (requiere GROQ_API_KEY)
 ```
 
 ### Controlar el servicio
@@ -114,3 +115,19 @@ Documentación de frontend:
 
 ## Licencia
 MIT
+
+
+## STT alternativo: Groq API
+Además del modo local offline, puedes usar Groq como backend de transcripción.
+
+Variables de entorno:
+- `GROQ_API_KEY` (requerida cuando `--stt-provider groq`)
+- `WHISPER_DICTATION_STT_PROVIDER` (`local` o `groq`, default `local`)
+- `WHISPER_DICTATION_GROQ_MODEL` (default `whisper-large-v3-turbo`)
+- `WHISPER_DICTATION_GROQ_URL` (default `https://api.groq.com/openai/v1/audio/transcriptions`)
+
+Ejemplo:
+```bash
+export GROQ_API_KEY="..."
+dictate --stt-provider groq --language es
+```

--- a/frontend_gui.py
+++ b/frontend_gui.py
@@ -2,7 +2,7 @@
 import queue
 import threading
 import tkinter as tk
-from tkinter import ttk, messagebox
+from tkinter import messagebox, ttk
 
 from frontend_config import load_config, save_config
 from frontend_service import (
@@ -64,9 +64,9 @@ class WhisperFrontendApp:
         actions = ttk.Frame(parent)
         actions.pack(fill="x", pady=(0, 16))
 
-        ttk.Button(actions, text="Iniciar servicio", command=lambda: self._service_action(start_service)).pack(side="left", padx=(0, 8))
-        ttk.Button(actions, text="Detener servicio", command=lambda: self._service_action(stop_service)).pack(side="left", padx=(0, 8))
-        ttk.Button(actions, text="Reiniciar servicio", command=lambda: self._service_action(restart_service)).pack(side="left", padx=(0, 8))
+        ttk.Button(actions, text="Iniciar servicio", command=lambda: self._service_action(start_service)).pack(side="left", padx=(0, 8))  # noqa: E501
+        ttk.Button(actions, text="Detener servicio", command=lambda: self._service_action(stop_service)).pack(side="left", padx=(0, 8))  # noqa: E501
+        ttk.Button(actions, text="Reiniciar servicio", command=lambda: self._service_action(restart_service)).pack(side="left", padx=(0, 8))  # noqa: E501
         ttk.Button(actions, text="Actualizar estado", command=self._refresh_async).pack(side="left")
 
         summary = ttk.LabelFrame(parent, text="Configuración activa", padding=12)
@@ -84,14 +84,14 @@ class WhisperFrontendApp:
         ttk.Entry(form, textvariable=self.key_var, width=20).grid(row=0, column=1, sticky="w", pady=6)
 
         ttk.Label(form, text="Idioma").grid(row=1, column=0, sticky="w", pady=6)
-        ttk.Combobox(form, textvariable=self.language_var, values=LANGUAGES, state="readonly", width=17).grid(row=1, column=1, sticky="w", pady=6)
+        ttk.Combobox(form, textvariable=self.language_var, values=LANGUAGES, state="readonly", width=17).grid(row=1, column=1, sticky="w", pady=6)  # noqa: E501
 
         ttk.Label(form, text="Modelo").grid(row=2, column=0, sticky="w", pady=6)
-        ttk.Combobox(form, textvariable=self.model_var, values=MODELS, state="readonly", width=17).grid(row=2, column=1, sticky="w", pady=6)
+        ttk.Combobox(form, textvariable=self.model_var, values=MODELS, state="readonly", width=17).grid(row=2, column=1, sticky="w", pady=6)  # noqa: E501
 
-        ttk.Checkbutton(form, text="Modo toggle", variable=self.toggle_var).grid(row=3, column=0, columnspan=2, sticky="w", pady=6)
+        ttk.Checkbutton(form, text="Modo toggle", variable=self.toggle_var).grid(row=3, column=0, columnspan=2, sticky="w", pady=6)  # noqa: E501
 
-        ttk.Button(form, text="Guardar configuración", command=self._save_config).grid(row=4, column=0, pady=(12, 0), sticky="w")
+        ttk.Button(form, text="Guardar configuración", command=self._save_config).grid(row=4, column=0, pady=(12, 0), sticky="w")  # noqa: E501
 
     def _build_logs_tab(self, parent):
         ttk.Button(parent, text="Recargar logs", command=self._refresh_async).pack(anchor="w", pady=(0, 8))
@@ -165,7 +165,7 @@ class WhisperFrontendApp:
 
 def main():
     root = tk.Tk()
-    app = WhisperFrontendApp(root)
+    WhisperFrontendApp(root)
     root.mainloop()
 
 

--- a/install.sh
+++ b/install.sh
@@ -172,8 +172,8 @@ systemctl --user restart "$SERVICE_NAME"
 info "Servicio habilitado y reiniciado."
 
 if [[ ":$PATH:" != *":$HOME/.local/bin:"* ]]; then
-    warn "~/.local/bin no está en tu PATH."
-    warn "Agrega esta línea a tu ~/.bashrc o ~/.zshrc:"
+    warn "$HOME/.local/bin no está en tu PATH."
+    warn "Agrega esta línea a tu $HOME/.bashrc o $HOME/.zshrc:"
     echo "    export PATH=\"\$HOME/.local/bin:\$PATH\""
 fi
 

--- a/tests/test_alt_stt_provider.py
+++ b/tests/test_alt_stt_provider.py
@@ -3,7 +3,6 @@ import pathlib
 
 import numpy as np
 
-
 MODULE_PATH = pathlib.Path(__file__).resolve().parents[1] / "whisper-dictation.py"
 
 

--- a/tests/test_alt_stt_provider.py
+++ b/tests/test_alt_stt_provider.py
@@ -1,0 +1,47 @@
+import importlib.util
+import pathlib
+
+import numpy as np
+
+
+MODULE_PATH = pathlib.Path(__file__).resolve().parents[1] / "whisper-dictation.py"
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("whisper_dictation", MODULE_PATH)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_audio_to_wav_bytes_has_riff_header():
+    m = load_module()
+    audio = np.zeros(1600, dtype=np.float32)
+    wav_bytes = m._audio_to_wav_bytes(audio, 16000)
+    assert wav_bytes[:4] == b"RIFF"
+    assert b"WAVE" in wav_bytes[:16]
+
+
+def test_multipart_body_contains_fields_and_file():
+    m = load_module()
+    boundary, body = m._multipart_body(
+        {"model": "whisper-large-v3-turbo"},
+        {"file": ("a.wav", b"123", "audio/wav")},
+    )
+    assert boundary
+    assert b'Content-Disposition: form-data; name="model"' in body
+    assert b'Content-Disposition: form-data; name="file"; filename="a.wav"' in body
+    assert b"audio/wav" in body
+
+
+def test_groq_without_key_raises_runtime_error(monkeypatch):
+    m = load_module()
+    monkeypatch.delenv("GROQ_API_KEY", raising=False)
+    audio = np.zeros(1600, dtype=np.float32)
+    try:
+        m.transcribe_with_groq(audio, 16000, None)
+    except RuntimeError as exc:
+        assert "GROQ_API_KEY" in str(exc)
+    else:
+        raise AssertionError("Expected RuntimeError when GROQ_API_KEY is missing")

--- a/tests/test_install_preflight.py
+++ b/tests/test_install_preflight.py
@@ -1,7 +1,6 @@
 import subprocess
 from pathlib import Path
 
-
 REPO_ROOT = Path(__file__).resolve().parents[1]
 INSTALL_SH = REPO_ROOT / "install.sh"
 

--- a/whisper-dictation.py
+++ b/whisper-dictation.py
@@ -24,6 +24,8 @@ import urllib.request
 import uuid
 import wave
 
+import numpy as np
+
 try:
     import sounddevice as sd
 except ImportError:  # pragma: no cover
@@ -154,8 +156,7 @@ def download_all_models():
 
 
 def _audio_to_wav_bytes(audio, sample_rate):
-    import numpy as np
-
+    
     pcm = np.clip(audio, -1.0, 1.0)
     pcm = (pcm * 32767).astype(np.int16)
     with io.BytesIO() as bio:
@@ -325,8 +326,20 @@ def _get_audio_backend():
                 source = line.split(":", 1)[1].strip()
         return {"ok": True, "backend": "pulseaudio", "server": server, "default_sink": sink, "default_source": source}
     if shutil.which("pipewire"):
-        return {"ok": True, "backend": "pipewire", "server": "pipewire", "default_sink": "unknown", "default_source": "unknown"}
-    return {"ok": False, "backend": "missing", "server": None, "default_sink": None, "default_source": None}
+        return {
+            "ok": True,
+            "backend": "pipewire",
+            "server": "pipewire",
+            "default_sink": "unknown",
+            "default_source": "unknown",
+        }
+    return {
+        "ok": False,
+        "backend": "missing",
+        "server": None,
+        "default_sink": None,
+        "default_source": None,
+    }
 
 
 def _get_cache_usage(path):
@@ -353,7 +366,21 @@ def _format_bytes(size):
 
 def _get_last_journal_error():
     result = _run_command(
-        ["journalctl", "--user", "-u", SERVICE_NAME, "--since", "24 hours ago", "-p", "err", "-n", "1", "--no-pager", "--output", "short-iso"],
+        [
+            "journalctl",
+            "--user",
+            "-u",
+            SERVICE_NAME,
+            "--since",
+            "24 hours ago",
+            "-p",
+            "err",
+            "-n",
+            "1",
+            "--no-pager",
+            "--output",
+            "short-iso",
+        ],
         timeout=0.8,
     )
     if result is None:
@@ -368,7 +395,17 @@ def _get_last_journal_error():
 
 def _get_last_activity():
     result = _run_command(
-        ["journalctl", "--user", "-u", SERVICE_NAME, "-n", "1", "--no-pager", "--output", "short-iso"],
+        [
+            "journalctl",
+            "--user",
+            "-u",
+            SERVICE_NAME,
+            "-n",
+            "1",
+            "--no-pager",
+            "--output",
+            "short-iso",
+        ],
         timeout=0.8,
     )
     if result is None or result.returncode == 124:
@@ -491,8 +528,7 @@ class Dictation:
                 self.audio_frames.append(indata.copy())
 
     def stop_and_transcribe(self):
-        import numpy as np
-
+        
         with self.lock:
             if not self.recording:
                 return
@@ -611,8 +647,11 @@ def main():
             "También configurable con WHISPER_DICTATION_STT_PROVIDER."
         ),
     )
-    parser.add_argument("--status", action="store_true",
-                        help="Muestra diagnóstico del servicio, modelo, sesión, audio, xdotool y último error del journal.")
+    parser.add_argument(
+        "--status",
+        action="store_true",
+        help="Muestra diagnóstico del servicio, modelo, sesión, audio, xdotool y último error del journal.",
+    )
     parser.add_argument("--json", action="store_true",
                         help="Con --status, emite el diagnóstico en JSON parseable.")
     args = parser.parse_args()

--- a/whisper-dictation.py
+++ b/whisper-dictation.py
@@ -4,28 +4,42 @@ Push-to-talk dictation para Linux X11 + KDE.
 Mantén presionada F12 para grabar. Al soltar, transcribe y escribe.
 
 Uso:
-  python3 whisper-dictation.py                   # Modelo automático según RAM
-  python3 whisper-dictation.py --key F10         # Cambiar tecla
-  python3 whisper-dictation.py --toggle          # Modo toggle
-  python3 whisper-dictation.py --model medium    # Modelo específico
-  python3 whisper-dictation.py --download-all    # Predescargar todos los modelos
+  python3 whisper-dictation.py                         # Modelo automático según RAM
+  python3 whisper-dictation.py --key F10               # Cambiar tecla
+  python3 whisper-dictation.py --toggle                # Modo toggle
+  python3 whisper-dictation.py --model medium          # Modelo específico
+  python3 whisper-dictation.py --stt-provider groq     # Usar API Groq Whisper
+  python3 whisper-dictation.py --download-all          # Predescargar modelos local
 """
 
 import argparse
+import io
+import json
 import os
 import subprocess
 import threading
 import time
+import urllib.request
+import uuid
+import wave
 
 import numpy as np
-import sounddevice as sd
-from faster_whisper import WhisperModel
-from pynput import keyboard
+
+try:
+    import sounddevice as sd
+except ImportError:  # pragma: no cover
+    sd = None
+
+try:
+    from pynput import keyboard
+except ImportError:  # pragma: no cover
+    keyboard = None
 
 # ---------- Configuración por defecto ----------
 DEFAULT_KEY = "f12"
 DEFAULT_MODEL = "auto"
 DEFAULT_LANGUAGE = "auto"
+DEFAULT_STT_PROVIDER = os.environ.get("WHISPER_DICTATION_STT_PROVIDER", "local").lower()
 SAMPLE_RATE = 16000
 CHANNELS = 1
 
@@ -38,6 +52,11 @@ INITIAL_PROMPT = (
 
 _xdg_cache = os.environ.get("XDG_CACHE_HOME", os.path.expanduser("~/.cache"))
 CACHE_DIR = os.path.join(_xdg_cache, "huggingface", "hub")
+GROQ_TRANSCRIPTIONS_URL = os.environ.get(
+    "WHISPER_DICTATION_GROQ_URL",
+    "https://api.groq.com/openai/v1/audio/transcriptions",
+)
+GROQ_MODEL = os.environ.get("WHISPER_DICTATION_GROQ_MODEL", "whisper-large-v3-turbo")
 # -----------------------------------------------
 
 # ---------- Registro de modelos ----------------
@@ -103,6 +122,8 @@ def is_model_cached(model_name):
 
 
 def ensure_model_available(model_name):
+    from faster_whisper import WhisperModel
+
     if not is_model_cached(model_name):
         print(f"[Whisper Dictation] Descargando modelo '{model_name}' (primera vez, puede tardar)...")
         notify("Whisper Dictation", f"⬇️ Descargando modelo '{model_name}'...", 60)
@@ -113,6 +134,8 @@ def ensure_model_available(model_name):
 
 
 def download_all_models():
+    from faster_whisper import WhisperModel
+
     print("[⬇] Iniciando descarga de todos los modelos...")
     notify("Whisper Dictation", "⬇️ Descargando todos los modelos...", 10)
     for model_name in MODEL_REGISTRY:
@@ -127,9 +150,86 @@ def download_all_models():
     notify("Whisper Dictation", "✅ Todos los modelos descargados.", 5)
 
 
+def _audio_to_wav_bytes(audio, sample_rate):
+    pcm = np.clip(audio, -1.0, 1.0)
+    pcm = (pcm * 32767).astype(np.int16)
+    with io.BytesIO() as bio:
+        with wave.open(bio, "wb") as wavf:
+            wavf.setnchannels(CHANNELS)
+            wavf.setsampwidth(2)
+            wavf.setframerate(sample_rate)
+            wavf.writeframes(pcm.tobytes())
+        return bio.getvalue()
+
+
+def _multipart_body(fields, files):
+    boundary = f"----WhisperDictation{uuid.uuid4().hex}"
+    chunks = []
+    for key, value in fields.items():
+        chunks.extend([
+            f"--{boundary}\r\n".encode(),
+            f'Content-Disposition: form-data; name="{key}"\r\n\r\n'.encode(),
+            str(value).encode(),
+            b"\r\n",
+        ])
+    for key, (filename, content, content_type) in files.items():
+        chunks.extend([
+            f"--{boundary}\r\n".encode(),
+            (
+                f'Content-Disposition: form-data; name="{key}"; filename="{filename}"\r\n'
+                f"Content-Type: {content_type}\r\n\r\n"
+            ).encode(),
+            content,
+            b"\r\n",
+        ])
+    chunks.append(f"--{boundary}--\r\n".encode())
+    return boundary, b"".join(chunks)
+
+
+def transcribe_with_groq(audio, sample_rate, language):
+    api_key = os.environ.get("GROQ_API_KEY")
+    if not api_key:
+        raise RuntimeError("GROQ_API_KEY no está configurada para usar --stt-provider groq")
+
+    wav_bytes = _audio_to_wav_bytes(audio, sample_rate)
+    fields = {
+        "model": GROQ_MODEL,
+        "temperature": "0",
+        "response_format": "json",
+        "prompt": INITIAL_PROMPT,
+    }
+    if language:
+        fields["language"] = language
+
+    boundary, body = _multipart_body(
+        fields=fields,
+        files={"file": ("recording.wav", wav_bytes, "audio/wav")},
+    )
+
+    request = urllib.request.Request(
+        GROQ_TRANSCRIPTIONS_URL,
+        data=body,
+        headers={
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": f"multipart/form-data; boundary={boundary}",
+            "Accept": "application/json",
+        },
+        method="POST",
+    )
+
+    try:
+        with urllib.request.urlopen(request, timeout=40) as response:
+            payload = json.loads(response.read().decode("utf-8"))
+    except Exception as exc:
+        raise RuntimeError(f"Fallo transcripción con Groq API: {exc}") from exc
+
+    return payload.get("text", "").strip()
+
+
 class Dictation:
-    def __init__(self, model_name, language, toggle_mode):
-        self.model = ensure_model_available(model_name)
+    def __init__(self, model_name, language, toggle_mode, stt_provider):
+        self.stt_provider = stt_provider
+        self.model = ensure_model_available(model_name) if stt_provider == "local" else None
         self.model_name = model_name
         self.language = language
         self.toggle_mode = toggle_mode
@@ -137,7 +237,8 @@ class Dictation:
         self.audio_frames = []
         self.lock = threading.Lock()
         lang_display = language if language else "auto (multilingüe)"
-        print(f"[Whisper Dictation] Listo. Modelo: {model_name} | Idioma: {lang_display}")
+        provider_desc = f"groq ({GROQ_MODEL})" if stt_provider == "groq" else model_name
+        print(f"[Whisper Dictation] Listo. STT: {provider_desc} | Idioma: {lang_display}")
         notify("Whisper Dictation", "✅ Listo — mantén F12 para dictar", 4)
 
     def start_recording(self):
@@ -182,9 +283,21 @@ class Dictation:
             notify("🎙 Dictado", "⚠️ Grabación muy corta, ignorada", 3)
             return
 
+        text = self._transcribe_audio(audio)
+        if text:
+            print(f'[✓] "{text}"', flush=True)
+            notify("✅ Transcripción", text, 5)
+            self._type_text(text)
+        else:
+            print("[!] No se detectó habla.")
+            notify("🎙 Dictado", "⚠️ No se detectó habla", 3)
+
+    def _transcribe_audio(self, audio):
+        if self.stt_provider == "groq":
+            return transcribe_with_groq(audio, SAMPLE_RATE, self.language)
+
         model_quality = MODEL_REGISTRY.get(self.model_name, {}).get("quality", 4)
         prompt = INITIAL_PROMPT if model_quality <= 3 else None
-
         segments, _ = self.model.transcribe(
             audio,
             language=self.language,
@@ -195,15 +308,7 @@ class Dictation:
             temperature=0.0,
             condition_on_previous_text=False,
         )
-
-        text = " ".join(seg.text for seg in segments).strip()
-        if text:
-            print(f'[✓] "{text}"', flush=True)
-            notify("✅ Transcripción", text, 5)
-            self._type_text(text)
-        else:
-            print("[!] No se detectó habla.")
-            notify("🎙 Dictado", "⚠️ No se detectó habla", 3)
+        return " ".join(seg.text for seg in segments).strip()
 
     def _type_text(self, text):
         time.sleep(0.15)
@@ -254,6 +359,11 @@ class Dictation:
 
 
 def main():
+    if sd is None or keyboard is None:
+        raise RuntimeError(
+            "Faltan dependencias runtime: instala 'sounddevice' y 'pynput' en el entorno activo."
+        )
+
     parser = argparse.ArgumentParser(description="Push-to-talk dictation con Whisper")
     parser.add_argument("--key", default=DEFAULT_KEY,
                         help=f"Tecla para activar (default: {DEFAULT_KEY})")
@@ -266,6 +376,16 @@ def main():
                         help="Modo toggle: presionar una vez inicia, presionar de nuevo detiene.")
     parser.add_argument("--download-all", action="store_true",
                         help="Descarga todos los modelos del registro y sale.")
+    parser.add_argument(
+        "--stt-provider",
+        default=DEFAULT_STT_PROVIDER,
+        choices=["local", "groq"],
+        help=(
+            "Proveedor de STT. 'local' usa faster-whisper offline; "
+            "'groq' usa la API compatible OpenAI de Groq. "
+            "También configurable con WHISPER_DICTATION_STT_PROVIDER."
+        ),
+    )
     args = parser.parse_args()
 
     if args.download_all:
@@ -274,7 +394,7 @@ def main():
 
     model_name = auto_select_model() if args.model == "auto" else args.model
     language = None if args.language == "auto" else args.language
-    dictation = Dictation(model_name, language, args.toggle)
+    dictation = Dictation(model_name, language, args.toggle, args.stt_provider)
 
     mode = "toggle" if args.toggle else "mantener presionada"
     print(f"[Whisper Dictation] Tecla activa: {args.key.upper()} ({mode})")


### PR DESCRIPTION
## Summary
- add configurable STT backend via  ( or )
- keep local  flow as default for backward compatibility
- add Groq Whisper transcription path using OpenAI-compatible audio transcription API
- add env-based config for provider/model/url\n- document Groq usage in README
- add tests for WAV/multipart helpers and missing API key validation

## Testing
-  *(blocked in this environment: pytest not installed)*