### PR TITLE
Fix clipboard race condition before paste

### DIFF
--- a/frontend_gui.py
+++ b/frontend_gui.py
@@ -64,9 +64,21 @@ class WhisperFrontendApp:
         actions = ttk.Frame(parent)
         actions.pack(fill="x", pady=(0, 16))
 
-        ttk.Button(actions, text="Iniciar servicio", command=lambda: self._service_action(start_service)).pack(side="left", padx=(0, 8))  # noqa: E501
-        ttk.Button(actions, text="Detener servicio", command=lambda: self._service_action(stop_service)).pack(side="left", padx=(0, 8))  # noqa: E501
-        ttk.Button(actions, text="Reiniciar servicio", command=lambda: self._service_action(restart_service)).pack(side="left", padx=(0, 8))  # noqa: E501
+        ttk.Button(
+            actions,
+            text="Iniciar servicio",
+            command=lambda: self._service_action(start_service),
+        ).pack(side="left", padx=(0, 8))
+        ttk.Button(
+            actions,
+            text="Detener servicio",
+            command=lambda: self._service_action(stop_service),
+        ).pack(side="left", padx=(0, 8))
+        ttk.Button(
+            actions,
+            text="Reiniciar servicio",
+            command=lambda: self._service_action(restart_service),
+        ).pack(side="left", padx=(0, 8))
         ttk.Button(actions, text="Actualizar estado", command=self._refresh_async).pack(side="left")
 
         summary = ttk.LabelFrame(parent, text="Configuración activa", padding=12)
@@ -84,14 +96,34 @@ class WhisperFrontendApp:
         ttk.Entry(form, textvariable=self.key_var, width=20).grid(row=0, column=1, sticky="w", pady=6)
 
         ttk.Label(form, text="Idioma").grid(row=1, column=0, sticky="w", pady=6)
-        ttk.Combobox(form, textvariable=self.language_var, values=LANGUAGES, state="readonly", width=17).grid(row=1, column=1, sticky="w", pady=6)  # noqa: E501
+        ttk.Combobox(
+            form,
+            textvariable=self.language_var,
+            values=LANGUAGES,
+            state="readonly",
+            width=17,
+        ).grid(row=1, column=1, sticky="w", pady=6)
 
         ttk.Label(form, text="Modelo").grid(row=2, column=0, sticky="w", pady=6)
-        ttk.Combobox(form, textvariable=self.model_var, values=MODELS, state="readonly", width=17).grid(row=2, column=1, sticky="w", pady=6)  # noqa: E501
+        ttk.Combobox(
+            form,
+            textvariable=self.model_var,
+            values=MODELS,
+            state="readonly",
+            width=17,
+        ).grid(row=2, column=1, sticky="w", pady=6)
 
-        ttk.Checkbutton(form, text="Modo toggle", variable=self.toggle_var).grid(row=3, column=0, columnspan=2, sticky="w", pady=6)  # noqa: E501
+        ttk.Checkbutton(
+            form,
+            text="Modo toggle",
+            variable=self.toggle_var,
+        ).grid(row=3, column=0, columnspan=2, sticky="w", pady=6)
 
-        ttk.Button(form, text="Guardar configuración", command=self._save_config).grid(row=4, column=0, pady=(12, 0), sticky="w")  # noqa: E501
+        ttk.Button(
+            form,
+            text="Guardar configuración",
+            command=self._save_config,
+        ).grid(row=4, column=0, pady=(12, 0), sticky="w")
 
     def _build_logs_tab(self, parent):
         ttk.Button(parent, text="Recargar logs", command=self._refresh_async).pack(anchor="w", pady=(0, 8))

--- a/install.sh
+++ b/install.sh
@@ -173,7 +173,7 @@ info "Servicio habilitado y reiniciado."
 
 if [[ ":$PATH:" != *":$HOME/.local/bin:"* ]]; then
     warn "$HOME/.local/bin no está en tu PATH."
-    warn "Agrega esta línea a tu $HOME/.bashrc o $HOME/.zshrc:"
+    warn "Agrega esta línea a tu ~/.bashrc o ~/.zshrc:"
     echo "    export PATH=\"\$HOME/.local/bin:\$PATH\""
 fi
 

--- a/tests/test_arg_parsing.py
+++ b/tests/test_arg_parsing.py
@@ -68,7 +68,9 @@ def test_main_parses_key_model_language_and_toggle(monkeypatch):
             raise AssertionError("listener should not invoke transcription during argument parsing")
 
     monkeypatch.setattr(module, "Dictation", DictationStub)
-    monkeypatch.setattr(module.keyboard, "Listener", ListenerStub)
+    keyboard_stub = types.SimpleNamespace(Listener=ListenerStub)
+    monkeypatch.setitem(sys.modules, "pynput", types.SimpleNamespace(keyboard=keyboard_stub))
+    monkeypatch.setitem(sys.modules, "pynput.keyboard", keyboard_stub)
     monkeypatch.setattr(
         sys,
         "argv",
@@ -90,7 +92,9 @@ def test_auto_model_is_resolved_before_dictation_is_created(monkeypatch):
 
     monkeypatch.setattr(module, "auto_select_model", lambda: "distil-large-v3")
     monkeypatch.setattr(module, "Dictation", DictationStub)
-    monkeypatch.setattr(module.keyboard, "Listener", ListenerStub)
+    keyboard_stub = types.SimpleNamespace(Listener=ListenerStub)
+    monkeypatch.setitem(sys.modules, "pynput", types.SimpleNamespace(keyboard=keyboard_stub))
+    monkeypatch.setitem(sys.modules, "pynput.keyboard", keyboard_stub)
     monkeypatch.setattr(sys, "argv", ["whisper-dictation.py", "--model", "auto"])
 
     module.main()

--- a/tests/test_clipboard_paste.py
+++ b/tests/test_clipboard_paste.py
@@ -1,0 +1,54 @@
+import importlib.util
+import subprocess
+from pathlib import Path
+
+
+def load_module():
+    module_path = Path(__file__).resolve().parents[1] / "whisper-dictation.py"
+    spec = importlib.util.spec_from_file_location("whisper_dictation", module_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_clipboard_paste_waits_for_new_text_before_pasting(monkeypatch):
+    module = load_module()
+    dictation = object.__new__(module.Dictation)
+    expected = "texto dictado".encode("utf-8")
+    previous = b"texto anterior"
+    reads = [previous, previous, expected]
+    calls = []
+
+    def fake_run(command, input=None, capture_output=False, check=False):
+        calls.append((command, input, capture_output, check))
+        if command == ["xclip", "-selection", "clipboard", "-o"]:
+            return subprocess.CompletedProcess(command, 0, stdout=reads.pop(0))
+        return subprocess.CompletedProcess(command, 0, stdout=b"")
+
+    monkeypatch.setattr(module.subprocess, "run", fake_run)
+    monkeypatch.setattr(module.time, "sleep", lambda _: None)
+
+    assert dictation._try_xclip("texto dictado") is True
+
+    paste_index = next(i for i, call in enumerate(calls) if call[0][:3] == ["xdotool", "key", "--clearmodifiers"])
+    verification_reads = [i for i, call in enumerate(calls) if call[0] == ["xclip", "-selection", "clipboard", "-o"]]
+    assert max(verification_reads) < paste_index
+
+
+def test_clipboard_paste_falls_back_when_clipboard_never_updates(monkeypatch):
+    module = load_module()
+    dictation = object.__new__(module.Dictation)
+    calls = []
+
+    def fake_run(command, input=None, capture_output=False, check=False):
+        calls.append(command)
+        if command == ["xclip", "-selection", "clipboard", "-o"]:
+            return subprocess.CompletedProcess(command, 0, stdout=b"texto anterior")
+        return subprocess.CompletedProcess(command, 0, stdout=b"")
+
+    monkeypatch.setattr(module.subprocess, "run", fake_run)
+    monkeypatch.setattr(module.time, "sleep", lambda _: None)
+    monkeypatch.setattr(module.time, "monotonic", iter([0.0, 0.2, 0.4, 0.6, 0.8, 1.1]).__next__)
+
+    assert dictation._try_xclip("texto dictado") is False
+    assert not any(command[:3] == ["xdotool", "key", "--clearmodifiers"] for command in calls)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,8 +1,12 @@
-import importlib
+import importlib.util
+from pathlib import Path
 
 
 def config_module(monkeypatch, tmp_path):
-    module = importlib.import_module("frontend_config")
+    module_path = Path(__file__).resolve().parents[1] / "frontend_config.py"
+    spec = importlib.util.spec_from_file_location("frontend_config", module_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
     monkeypatch.setattr(module, "CONFIG_DIR", tmp_path / "whisper-dictation")
     monkeypatch.setattr(module, "CONFIG_PATH", tmp_path / "whisper-dictation" / "config.json")
     return module

--- a/whisper-dictation.py
+++ b/whisper-dictation.py
@@ -36,6 +36,7 @@ try:
 except ImportError:  # pragma: no cover
     keyboard = None
 
+
 # ---------- Configuración por defecto ----------
 DEFAULT_KEY = "f12"
 DEFAULT_MODEL = "auto"
@@ -45,6 +46,8 @@ SERVICE_NAME = "whisper-dictation"
 CONFIG_PATH = os.path.expanduser("~/.config/whisper-dictation/config.json")
 SAMPLE_RATE = 16000
 CHANNELS = 1
+CLIPBOARD_SETTLE_TIMEOUT_SECONDS = 1.0
+CLIPBOARD_RESTORE_DELAY_SECONDS = 0.25
 
 INITIAL_PROMPT = (
     "Transcripción en español con términos técnicos en inglés: "
@@ -491,6 +494,29 @@ def print_status(report, json_output=False):
     print(f"dependencies:   {'ok' if not missing else 'missing ' + ', '.join(missing)}")
 
 
+class ClipboardTool:
+    def __init__(self, name, read_command, write_command):
+        self.name = name
+        self.read_command = read_command
+        self.write_command = write_command
+
+    @classmethod
+    def xclip(cls):
+        return cls(
+            name="xclip",
+            read_command=["xclip", "-selection", "clipboard", "-o"],
+            write_command=["xclip", "-selection", "clipboard"],
+        )
+
+    @classmethod
+    def xsel(cls):
+        return cls(
+            name="xsel",
+            read_command=["xsel", "--clipboard", "--output"],
+            write_command=["xsel", "--clipboard", "--input"],
+        )
+
+
 class Dictation:
     def __init__(self, model_name, language, toggle_mode, stt_provider=DEFAULT_STT_PROVIDER):
         self.stt_provider = stt_provider
@@ -578,42 +604,51 @@ class Dictation:
 
     def _type_text(self, text):
         time.sleep(0.15)
-        if self._try_xclip(text):
+        if self._try_clipboard_paste(ClipboardTool.xclip(), text, ["ctrl+shift+v", "ctrl+v"]):
             return
-        if self._try_xsel(text):
+        if self._try_clipboard_paste(ClipboardTool.xsel(), text, ["ctrl+v"]):
             return
         self._fallback_xdotool(text)
 
-    def _try_xclip(self, text):
+    def _try_clipboard_paste(self, clipboard, text, paste_keys):
+        text_bytes = text.encode("utf-8")
         try:
-            prev = subprocess.run(["xclip", "-selection", "clipboard", "-o"], capture_output=True)
-            subprocess.run(["xclip", "-selection", "clipboard"], input=text.encode("utf-8"), check=True)
-            try:
-                subprocess.run(["xdotool", "key", "--clearmodifiers", "ctrl+shift+v"], check=True)
-            except subprocess.CalledProcessError:
-                subprocess.run(["xdotool", "key", "--clearmodifiers", "ctrl+v"], check=True)
-            time.sleep(0.1)
-            if prev.returncode == 0:
-                subprocess.run(["xclip", "-selection", "clipboard"], input=prev.stdout, check=False)
-            return True
+            prev = subprocess.run(clipboard.read_command, capture_output=True)
+            subprocess.run(clipboard.write_command, input=text_bytes, check=True)
+            if not self._wait_for_clipboard(clipboard, text_bytes):
+                print(f"[!] {clipboard.name} no confirmó el texto nuevo; usando fallback xdotool type.")
+                return False
+
+            for key in paste_keys:
+                try:
+                    subprocess.run(["xdotool", "key", "--clearmodifiers", key], check=True)
+                    time.sleep(CLIPBOARD_RESTORE_DELAY_SECONDS)
+                    return True
+                except subprocess.CalledProcessError:
+                    continue
+            return False
         except FileNotFoundError:
             return False
         except subprocess.CalledProcessError:
             return False
+        finally:
+            if "prev" in locals() and prev.returncode == 0:
+                subprocess.run(clipboard.write_command, input=prev.stdout, check=False)
+
+    def _wait_for_clipboard(self, clipboard, expected):
+        deadline = time.monotonic() + CLIPBOARD_SETTLE_TIMEOUT_SECONDS
+        while time.monotonic() < deadline:
+            current = subprocess.run(clipboard.read_command, capture_output=True)
+            if current.returncode == 0 and current.stdout == expected:
+                return True
+            time.sleep(0.05)
+        return False
+
+    def _try_xclip(self, text):
+        return self._try_clipboard_paste(ClipboardTool.xclip(), text, ["ctrl+shift+v", "ctrl+v"])
 
     def _try_xsel(self, text):
-        try:
-            prev = subprocess.run(["xsel", "--clipboard", "--output"], capture_output=True)
-            subprocess.run(["xsel", "--clipboard", "--input"], input=text.encode("utf-8"), check=True)
-            subprocess.run(["xdotool", "key", "--clearmodifiers", "ctrl+v"], check=True)
-            time.sleep(0.1)
-            if prev.returncode == 0:
-                subprocess.run(["xsel", "--clipboard", "--input"], input=prev.stdout, check=False)
-            return True
-        except FileNotFoundError:
-            return False
-        except subprocess.CalledProcessError:
-            return False
+        return self._try_clipboard_paste(ClipboardTool.xsel(), text, ["ctrl+v"])
 
     def _fallback_xdotool(self, text):
         print("[!] xclip y xsel no disponibles. Usando xdotool type (puede perder tildes).")

--- a/whisper-dictation.py
+++ b/whisper-dictation.py
@@ -616,7 +616,10 @@ class Dictation:
             prev = subprocess.run(clipboard.read_command, capture_output=True)
             subprocess.run(clipboard.write_command, input=text_bytes, check=True)
             if not self._wait_for_clipboard(clipboard, text_bytes):
-                print(f"[!] {clipboard.name}: no confirmó el texto nuevo; se usa fallback con xdotool type.")
+                print(
+                    f"[!] {clipboard.name}: no confirmó actualización del portapapeles; "
+                    "se usará fallback con xdotool type."
+                )
                 return False
 
             for key in paste_keys:

--- a/whisper-dictation.py
+++ b/whisper-dictation.py
@@ -616,7 +616,7 @@ class Dictation:
             prev = subprocess.run(clipboard.read_command, capture_output=True)
             subprocess.run(clipboard.write_command, input=text_bytes, check=True)
             if not self._wait_for_clipboard(clipboard, text_bytes):
-                print(f"[!] {clipboard.name} no confirmó el texto nuevo; usando fallback xdotool type.")
+                print(f"[!] {clipboard.name}: no confirmó el texto nuevo; se usa fallback con xdotool type.")
                 return False
 
             for key in paste_keys:


### PR DESCRIPTION
## Summary
- fix a race condition where clipboard paste could happen before the new dictation text was fully available
- add a clipboard synchronization wait loop before sending paste keys
- restore previous clipboard content in a  block after paste attempts
- keep xclip/xsel behavior unified via shared clipboard helper logic

- ## Tests
- ...........                                                              [100%]
11 passed in 0.05s\n- new regression tests in 