### PR TITLE
feat: improve GUI config sync and tray behavior

### DIFF
--- a/frontend_config.py
+++ b/frontend_config.py
@@ -8,7 +8,8 @@ DEFAULT_CONFIG = {
     "key": "f12",
     "toggle": False,
     "language": "es",
-    "model": "base",
+    "model": "auto",
+    "stt_provider": "local",
 }
 
 

--- a/frontend_gui.py
+++ b/frontend_gui.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python3
+import os
 import queue
+import socket
+import tempfile
 import threading
 import tkinter as tk
 from tkinter import messagebox, ttk
@@ -13,15 +16,102 @@ from frontend_service import (
     tail_service_logs,
 )
 
-MODELS = ["tiny", "base", "small", "medium", "large-v3"]
+MODELS = ["auto", "tiny", "base", "small", "medium", "large-v3"]
 LANGUAGES = ["es", "en", "auto"]
+STT_PROVIDERS = ["local", "groq"]
+INSTANCE_SOCKET = os.path.join(
+    os.environ.get("XDG_RUNTIME_DIR") or tempfile.gettempdir(),
+    f"whisper-ptt-gui-{os.getuid()}.sock",
+)
+
+
+def focus_existing_instance():
+    try:
+        client = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        client.settimeout(0.2)
+        client.connect(INSTANCE_SOCKET)
+        client.sendall(b"show")
+        client.close()
+        return True
+    except OSError:
+        try:
+            os.unlink(INSTANCE_SOCKET)
+        except FileNotFoundError:
+            pass
+        return False
+
+
+class SingleInstanceServer:
+    def __init__(self, app):
+        self.app = app
+        self.sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        self.sock.bind(INSTANCE_SOCKET)
+        self.sock.listen(1)
+        threading.Thread(target=self._serve, daemon=True).start()
+
+    def _serve(self):
+        while True:
+            try:
+                conn, _ = self.sock.accept()
+                data = conn.recv(32)
+                conn.close()
+            except OSError:
+                return
+            if data.startswith(b"show"):
+                self.app.root.after(0, self.app.show_window)
+
+    def close(self):
+        try:
+            self.sock.close()
+        finally:
+            try:
+                os.unlink(INSTANCE_SOCKET)
+            except FileNotFoundError:
+                pass
+
+
+class TrayController:
+    def __init__(self, app):
+        self.app = app
+        self.icon = None
+        self.available = False
+        try:
+            import pystray
+            from PIL import Image, ImageDraw
+        except ImportError:
+            return
+
+        image = Image.new("RGB", (64, 64), "#1f2937")
+        draw = ImageDraw.Draw(image)
+        draw.ellipse((14, 8, 50, 44), fill="#22c55e")
+        draw.rectangle((28, 42, 36, 54), fill="#22c55e")
+        draw.rectangle((20, 54, 44, 59), fill="#22c55e")
+        self.icon = pystray.Icon(
+            "whisper-ptt",
+            image,
+            "whisper-ptt",
+            menu=pystray.Menu(
+                pystray.MenuItem("Mostrar", lambda: self.app.root.after(0, self.app.show_window), default=True),
+                pystray.MenuItem("Reiniciar servicio", lambda: self.app._service_action(restart_service)),
+                pystray.MenuItem("Salir", lambda: self.app.root.after(0, self.app.quit_app)),
+            ),
+        )
+        self.available = True
+
+    def start(self):
+        if self.icon:
+            threading.Thread(target=self.icon.run, daemon=True).start()
+
+    def stop(self):
+        if self.icon:
+            self.icon.stop()
 
 
 class WhisperFrontendApp:
     def __init__(self, root):
         self.root = root
         self.root.title("whisper-ptt frontend")
-        self.root.geometry("760x560")
+        self.root.geometry("760x600")
         self.queue = queue.Queue()
         self.config = load_config()
         self.status_var = tk.StringVar(value="Cargando estado...")
@@ -32,6 +122,12 @@ class WhisperFrontendApp:
         self.toggle_var = tk.BooleanVar(value=self.config["toggle"])
         self.language_var = tk.StringVar(value=self.config["language"])
         self.model_var = tk.StringVar(value=self.config["model"])
+        self.stt_provider_var = tk.StringVar(value=self.config.get("stt_provider", "local"))
+
+        self.instance_server = SingleInstanceServer(self)
+        self.tray = TrayController(self)
+        self.tray.start()
+        self.root.protocol("WM_DELETE_WINDOW", self.hide_window)
 
         self._build_ui()
         self._refresh_async()
@@ -40,22 +136,22 @@ class WhisperFrontendApp:
     def _build_ui(self):
         header = ttk.Frame(self.root, padding=12)
         header.pack(fill="x")
-
         ttk.Label(header, text="whisper-ptt", font=("TkDefaultFont", 16, "bold")).pack(anchor="w")
         ttk.Label(header, textvariable=self.status_var).pack(anchor="w", pady=(4, 0))
         ttk.Label(header, textvariable=self.mic_var).pack(anchor="w")
+        tray_text = (
+            "Icono de bandeja activo" if self.tray.available else "Bandeja no disponible (pystray/pillow faltante)"
+        )
+        ttk.Label(header, text=tray_text).pack(anchor="w")
 
         notebook = ttk.Notebook(self.root)
         notebook.pack(fill="both", expand=True, padx=12, pady=12)
-
         status_tab = ttk.Frame(notebook, padding=12)
         config_tab = ttk.Frame(notebook, padding=12)
         logs_tab = ttk.Frame(notebook, padding=12)
-
         notebook.add(status_tab, text="Estado")
         notebook.add(config_tab, text="Configuración")
         notebook.add(logs_tab, text="Logs")
-
         self._build_status_tab(status_tab)
         self._build_config_tab(config_tab)
         self._build_logs_tab(logs_tab)
@@ -63,15 +159,18 @@ class WhisperFrontendApp:
     def _build_status_tab(self, parent):
         actions = ttk.Frame(parent)
         actions.pack(fill="x", pady=(0, 16))
-
-        ttk.Button(actions, text="Iniciar servicio", command=lambda: self._service_action(start_service)).pack(side="left", padx=(0, 8))  # noqa: E501
-        ttk.Button(actions, text="Detener servicio", command=lambda: self._service_action(stop_service)).pack(side="left", padx=(0, 8))  # noqa: E501
-        ttk.Button(actions, text="Reiniciar servicio", command=lambda: self._service_action(restart_service)).pack(side="left", padx=(0, 8))  # noqa: E501
+        ttk.Button(actions, text="Iniciar servicio", command=lambda: self._service_action(start_service)).pack(
+            side="left", padx=(0, 8)
+        )
+        ttk.Button(actions, text="Detener servicio", command=lambda: self._service_action(stop_service)).pack(
+            side="left", padx=(0, 8)
+        )
+        ttk.Button(actions, text="Reiniciar servicio", command=lambda: self._service_action(restart_service)).pack(
+            side="left", padx=(0, 8)
+        )
         ttk.Button(actions, text="Actualizar estado", command=self._refresh_async).pack(side="left")
-
         summary = ttk.LabelFrame(parent, text="Configuración activa", padding=12)
         summary.pack(fill="x")
-
         self.summary_label = ttk.Label(summary, justify="left")
         self.summary_label.pack(anchor="w")
         self._update_summary()
@@ -79,19 +178,26 @@ class WhisperFrontendApp:
     def _build_config_tab(self, parent):
         form = ttk.Frame(parent)
         form.pack(fill="x")
-
         ttk.Label(form, text="Tecla").grid(row=0, column=0, sticky="w", pady=6)
         ttk.Entry(form, textvariable=self.key_var, width=20).grid(row=0, column=1, sticky="w", pady=6)
-
         ttk.Label(form, text="Idioma").grid(row=1, column=0, sticky="w", pady=6)
-        ttk.Combobox(form, textvariable=self.language_var, values=LANGUAGES, state="readonly", width=17).grid(row=1, column=1, sticky="w", pady=6)  # noqa: E501
-
+        ttk.Combobox(form, textvariable=self.language_var, values=LANGUAGES, state="readonly", width=17).grid(
+            row=1, column=1, sticky="w", pady=6
+        )
         ttk.Label(form, text="Modelo").grid(row=2, column=0, sticky="w", pady=6)
-        ttk.Combobox(form, textvariable=self.model_var, values=MODELS, state="readonly", width=17).grid(row=2, column=1, sticky="w", pady=6)  # noqa: E501
-
-        ttk.Checkbutton(form, text="Modo toggle", variable=self.toggle_var).grid(row=3, column=0, columnspan=2, sticky="w", pady=6)  # noqa: E501
-
-        ttk.Button(form, text="Guardar configuración", command=self._save_config).grid(row=4, column=0, pady=(12, 0), sticky="w")  # noqa: E501
+        ttk.Combobox(form, textvariable=self.model_var, values=MODELS, state="readonly", width=17).grid(
+            row=2, column=1, sticky="w", pady=6
+        )
+        ttk.Label(form, text="Proveedor STT").grid(row=3, column=0, sticky="w", pady=6)
+        ttk.Combobox(form, textvariable=self.stt_provider_var, values=STT_PROVIDERS, state="readonly", width=17).grid(
+            row=3, column=1, sticky="w", pady=6
+        )
+        ttk.Checkbutton(form, text="Modo toggle", variable=self.toggle_var).grid(
+            row=4, column=0, columnspan=2, sticky="w", pady=6
+        )
+        ttk.Button(form, text="Guardar y aplicar", command=self._save_config).grid(
+            row=5, column=0, pady=(12, 0), sticky="w"
+        )
 
     def _build_logs_tab(self, parent):
         ttk.Button(parent, text="Recargar logs", command=self._refresh_async).pack(anchor="w", pady=(0, 8))
@@ -106,7 +212,8 @@ class WhisperFrontendApp:
                 f"Tecla: {self.key_var.get().upper()}\n"
                 f"Idioma: {self.language_var.get()}\n"
                 f"Modelo: {self.model_var.get()}\n"
-                f"Modo toggle: {'sí' if self.toggle_var.get() else 'no'}"
+                f"Proveedor STT: {self.stt_provider_var.get()}\n"
+                "Modo toggle: " + ("sí" if self.toggle_var.get() else "no")
             )
         )
 
@@ -116,11 +223,13 @@ class WhisperFrontendApp:
             "toggle": self.toggle_var.get(),
             "language": self.language_var.get(),
             "model": self.model_var.get(),
+            "stt_provider": self.stt_provider_var.get(),
         }
         save_config(self.config)
         self._update_summary()
-        self.mic_var.set("Micrófono: configuración guardada")
-        messagebox.showinfo("whisper-ptt", "Configuración guardada. Reinicia el servicio para aplicar cambios.")
+        self.mic_var.set("Micrófono: configuración guardada, reiniciando servicio...")
+        self._service_action(restart_service)
+        messagebox.showinfo("whisper-ptt", "Configuración guardada y servicio reiniciado para aplicar cambios.")
 
     def _service_action(self, action):
         threading.Thread(target=self._run_service_action, args=(action,), daemon=True).start()
@@ -150,20 +259,37 @@ class WhisperFrontendApp:
                     self.logs_text.insert("1.0", payload or "Sin logs disponibles")
                     self.logs_text.configure(state="disabled")
                 elif event == "service_action":
-                    if value == 0:
-                        self.status_var.set("Acción ejecutada correctamente")
-                    else:
-                        self.status_var.set("La acción del servicio devolvió error")
-                        if payload:
-                            self.mic_var.set(payload)
+                    self.status_var.set(
+                        "Acción ejecutada correctamente" if value == 0 else "La acción del servicio devolvió error"
+                    )
+                    if payload:
+                        self.mic_var.set(payload)
                 elif event == "refresh":
                     self._refresh_async()
         except queue.Empty:
             pass
         self.root.after(300, self._poll_queue)
 
+    def show_window(self):
+        self.root.deiconify()
+        self.root.lift()
+        self.root.focus_force()
+
+    def hide_window(self):
+        if self.tray.available:
+            self.root.withdraw()
+        else:
+            self.quit_app()
+
+    def quit_app(self):
+        self.tray.stop()
+        self.instance_server.close()
+        self.root.destroy()
+
 
 def main():
+    if focus_existing_instance():
+        return
     root = tk.Tk()
     WhisperFrontendApp(root)
     root.mainloop()

--- a/install.sh
+++ b/install.sh
@@ -113,6 +113,7 @@ APP_NAME="whisper-dictation"
 VENV_DIR="$HOME/.local/share/${APP_NAME}"
 LOCAL_BIN_DIR="$HOME/.local/bin"
 SYSTEMD_DIR="$HOME/.config/systemd/user"
+AUTOSTART_DIR="$HOME/.config/autostart"
 SERVICE_NAME="whisper-dictation"
 SERVICE_PATH="$SYSTEMD_DIR/${SERVICE_NAME}.service"
 INSTALL_MODE="INSTALL"
@@ -150,7 +151,7 @@ fi
 
 step "Instalando librerías Python (puede tardar varios minutos)..."
 "$VENV_DIR/bin/pip" install --upgrade pip --quiet
-"$VENV_DIR/bin/pip" install faster-whisper sounddevice numpy pynput --quiet
+"$VENV_DIR/bin/pip" install faster-whisper sounddevice numpy pynput pystray pillow --quiet
 info "Librerías Python instaladas."
 
 step "Instalando archivos..."
@@ -162,6 +163,11 @@ cp frontend_config.py "$LOCAL_BIN_DIR/frontend_config.py"
 cp frontend_service.py "$LOCAL_BIN_DIR/frontend_service.py"
 chmod +x "$LOCAL_BIN_DIR/dictate"
 chmod +x "$LOCAL_BIN_DIR/whisper-ptt-gui"
+
+step "Configurando autostart de GUI..."
+mkdir -p "$AUTOSTART_DIR"
+printf '%s\n' "[Desktop Entry]" "Type=Application" "Name=whisper-ptt GUI" "Comment=Frontend de control para whisper-ptt" "Exec=$LOCAL_BIN_DIR/whisper-ptt-gui" "Terminal=false" "X-GNOME-Autostart-enabled=true" > "$AUTOSTART_DIR/whisper-ptt-gui.desktop"
+info "GUI configurada para iniciar al iniciar sesión."
 
 step "Configurando servicio systemd..."
 mkdir -p "$SYSTEMD_DIR"

--- a/tests/test_arg_parsing.py
+++ b/tests/test_arg_parsing.py
@@ -58,8 +58,8 @@ def test_main_parses_key_model_language_and_toggle(monkeypatch):
     created = {}
 
     class DictationStub:
-        def __init__(self, model_name, language, toggle_mode):
-            created.update(model_name=model_name, language=language, toggle_mode=toggle_mode)
+        def __init__(self, model_name, language, toggle_mode, stt_provider="local"):
+            created.update(model_name=model_name, language=language, toggle_mode=toggle_mode, stt_provider=stt_provider)
 
         def start_recording(self):
             raise AssertionError("listener should not invoke recording during argument parsing")
@@ -77,7 +77,7 @@ def test_main_parses_key_model_language_and_toggle(monkeypatch):
 
     module.main()
 
-    assert created == {"model_name": "small", "language": None, "toggle_mode": True}
+    assert created == {"model_name": "small", "language": None, "toggle_mode": True, "stt_provider": "local"}
 
 
 def test_auto_model_is_resolved_before_dictation_is_created(monkeypatch):
@@ -85,7 +85,7 @@ def test_auto_model_is_resolved_before_dictation_is_created(monkeypatch):
     created = {}
 
     class DictationStub:
-        def __init__(self, model_name, language, toggle_mode):
+        def __init__(self, model_name, language, toggle_mode, stt_provider="local"):
             created["model_name"] = model_name
 
     monkeypatch.setattr(module, "auto_select_model", lambda: "distil-large-v3")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,8 +1,12 @@
-import importlib
+import importlib.util
+from pathlib import Path
 
 
 def config_module(monkeypatch, tmp_path):
-    module = importlib.import_module("frontend_config")
+    module_path = Path(__file__).resolve().parents[1] / "frontend_config.py"
+    spec = importlib.util.spec_from_file_location("frontend_config", module_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
     monkeypatch.setattr(module, "CONFIG_DIR", tmp_path / "whisper-dictation")
     monkeypatch.setattr(module, "CONFIG_PATH", tmp_path / "whisper-dictation" / "config.json")
     return module
@@ -16,7 +20,7 @@ def test_load_config_returns_defaults_when_file_is_missing(monkeypatch, tmp_path
 
 def test_save_config_creates_parent_directory_and_round_trips(monkeypatch, tmp_path):
     module = config_module(monkeypatch, tmp_path)
-    config = {"key": "f10", "toggle": True, "language": "auto", "model": "small"}
+    config = {"key": "f10", "toggle": True, "language": "auto", "model": "small", "stt_provider": "groq"}
 
     module.save_config(config)
 

--- a/whisper-dictation.py
+++ b/whisper-dictation.py
@@ -108,8 +108,7 @@ def auto_select_model(quiet=False):
     available = get_available_ram_mb()
     usable = available * 0.75
     candidates = {
-        k: v for k, v in MODEL_REGISTRY.items()
-        if v["ram_mb"] <= usable and v["multilingual"] and v["cpu_viable"]
+        k: v for k, v in MODEL_REGISTRY.items() if v["ram_mb"] <= usable and v["multilingual"] and v["cpu_viable"]
     }
     if not candidates:
         if not quiet:
@@ -156,7 +155,7 @@ def download_all_models():
 
 
 def _audio_to_wav_bytes(audio, sample_rate):
-    
+
     pcm = np.clip(audio, -1.0, 1.0)
     pcm = (pcm * 32767).astype(np.int16)
     with io.BytesIO() as bio:
@@ -172,22 +171,26 @@ def _multipart_body(fields, files):
     boundary = f"----WhisperDictation{uuid.uuid4().hex}"
     chunks = []
     for key, value in fields.items():
-        chunks.extend([
-            f"--{boundary}\r\n".encode(),
-            f'Content-Disposition: form-data; name="{key}"\r\n\r\n'.encode(),
-            str(value).encode(),
-            b"\r\n",
-        ])
+        chunks.extend(
+            [
+                f"--{boundary}\r\n".encode(),
+                f'Content-Disposition: form-data; name="{key}"\r\n\r\n'.encode(),
+                str(value).encode(),
+                b"\r\n",
+            ]
+        )
     for key, (filename, content, content_type) in files.items():
-        chunks.extend([
-            f"--{boundary}\r\n".encode(),
-            (
-                f'Content-Disposition: form-data; name="{key}"; filename="{filename}"\r\n'
-                f"Content-Type: {content_type}\r\n\r\n"
-            ).encode(),
-            content,
-            b"\r\n",
-        ])
+        chunks.extend(
+            [
+                f"--{boundary}\r\n".encode(),
+                (
+                    f'Content-Disposition: form-data; name="{key}"; filename="{filename}"\r\n'
+                    f"Content-Type: {content_type}\r\n\r\n"
+                ).encode(),
+                content,
+                b"\r\n",
+            ]
+        )
     chunks.append(f"--{boundary}--\r\n".encode())
     return boundary, b"".join(chunks)
 
@@ -255,12 +258,13 @@ def _command_output(command, timeout=0.8):
     return (result.stdout or result.stderr or "").strip()
 
 
-def _load_status_config():
+def load_runtime_config():
     config = {
         "key": DEFAULT_KEY,
         "toggle": False,
         "language": DEFAULT_LANGUAGE,
         "model": DEFAULT_MODEL,
+        "stt_provider": DEFAULT_STT_PROVIDER,
     }
     try:
         with open(CONFIG_PATH, encoding="utf-8") as f:
@@ -417,7 +421,7 @@ def _get_last_activity():
 
 
 def collect_status(cli_model=DEFAULT_MODEL):
-    config = _load_status_config()
+    config = load_runtime_config()
     configured_model = config.get("model") or cli_model or DEFAULT_MODEL
     if configured_model == "auto":
         model_name = auto_select_model(quiet=True)
@@ -528,7 +532,7 @@ class Dictation:
                 self.audio_frames.append(indata.copy())
 
     def stop_and_transcribe(self):
-        
+
         with self.lock:
             if not self.recording:
                 return
@@ -626,20 +630,26 @@ class Dictation:
 
 def main():
     parser = argparse.ArgumentParser(description="Push-to-talk dictation con Whisper")
-    parser.add_argument("--key", default=DEFAULT_KEY,
-                        help=f"Tecla para activar (default: {DEFAULT_KEY})")
-    parser.add_argument("--model", default=DEFAULT_MODEL,
-                        choices=["auto"] + list(MODEL_REGISTRY.keys()),
-                        help="Modelo Whisper a usar. 'auto' selecciona el mejor según RAM disponible.")
-    parser.add_argument("--language", default=DEFAULT_LANGUAGE,
-                        help="Código ISO del idioma (es, en, fr...) o 'auto' para detección multilingüe.")
-    parser.add_argument("--toggle", action="store_true",
-                        help="Modo toggle: presionar una vez inicia, presionar de nuevo detiene.")
-    parser.add_argument("--download-all", action="store_true",
-                        help="Descarga todos los modelos del registro y sale.")
+    parser.add_argument("--key", default=None, help=f"Tecla para activar (default/config: {DEFAULT_KEY})")
+    parser.add_argument(
+        "--model",
+        default=None,
+        choices=["auto"] + list(MODEL_REGISTRY.keys()),
+        help="Modelo Whisper a usar. 'auto' selecciona el mejor según RAM disponible.",
+    )
+    parser.add_argument(
+        "--language", default=None, help="Código ISO del idioma (es, en, fr...) o 'auto' para detección multilingüe."
+    )
+    parser.add_argument(
+        "--toggle",
+        action="store_true",
+        default=None,
+        help="Modo toggle: presionar una vez inicia, presionar de nuevo detiene.",
+    )
+    parser.add_argument("--download-all", action="store_true", help="Descarga todos los modelos del registro y sale.")
     parser.add_argument(
         "--stt-provider",
-        default=DEFAULT_STT_PROVIDER,
+        default=None,
         choices=["local", "groq"],
         help=(
             "Proveedor de STT. 'local' usa faster-whisper offline; "
@@ -652,12 +662,14 @@ def main():
         action="store_true",
         help="Muestra diagnóstico del servicio, modelo, sesión, audio, xdotool y último error del journal.",
     )
-    parser.add_argument("--json", action="store_true",
-                        help="Con --status, emite el diagnóstico en JSON parseable.")
+    parser.add_argument("--json", action="store_true", help="Con --status, emite el diagnóstico en JSON parseable.")
     args = parser.parse_args()
 
+    runtime_config = load_runtime_config()
+    effective_model = args.model or runtime_config.get("model", DEFAULT_MODEL)
+
     if args.status:
-        report = collect_status(args.model)
+        report = collect_status(effective_model)
         print_status(report, json_output=args.json)
         return
 
@@ -665,20 +677,22 @@ def main():
         download_all_models()
         return
 
-    model_name = auto_select_model() if args.model == "auto" else args.model
-    language = None if args.language == "auto" else args.language
+    effective_key = (args.key or runtime_config.get("key", DEFAULT_KEY)).lower()
+    effective_language = args.language or runtime_config.get("language", DEFAULT_LANGUAGE)
+    effective_toggle = runtime_config.get("toggle", False) if args.toggle is None else args.toggle
+    effective_stt_provider = args.stt_provider or runtime_config.get("stt_provider", DEFAULT_STT_PROVIDER)
+
+    model_name = auto_select_model() if effective_model == "auto" else effective_model
+    language = None if effective_language == "auto" else effective_language
 
     global sd, keyboard
     import sounddevice as sd
     from pynput import keyboard
 
-    dictation = Dictation(model_name, language, args.toggle)
-    dictation.stt_provider = args.stt_provider
-    if args.stt_provider == "groq":
-        dictation.model = None
+    dictation = Dictation(model_name, language, effective_toggle, effective_stt_provider)
 
-    mode = "toggle" if args.toggle else "mantener presionada"
-    print(f"[Whisper Dictation] Tecla activa: {args.key.upper()} ({mode})")
+    mode = "toggle" if effective_toggle else "mantener presionada"
+    print(f"[Whisper Dictation] Tecla activa: {effective_key.upper()} ({mode})")
     print("[Whisper Dictation] Ctrl+C para salir\n")
 
     pressed = False
@@ -689,8 +703,8 @@ def main():
             key_name = key.name if hasattr(key, "name") else key.char
         except AttributeError:
             return
-        if key_name == args.key.lower():
-            if args.toggle:
+        if key_name == effective_key:
+            if effective_toggle:
                 if not pressed:
                     pressed = True
                     dictation.start_recording()
@@ -704,13 +718,13 @@ def main():
 
     def on_release(key):
         nonlocal pressed
-        if args.toggle:
+        if effective_toggle:
             return
         try:
             key_name = key.name if hasattr(key, "name") else key.char
         except AttributeError:
             return
-        if key_name == args.key.lower() and pressed:
+        if key_name == effective_key and pressed:
             pressed = False
             threading.Thread(target=dictation.stop_and_transcribe, daemon=True).start()
 


### PR DESCRIPTION
$## Summary\n- Make `dictate` load the GUI-saved runtime config by default, so key/model/language/toggle/provider changes actually affect the service after restart.\n- Add single-instance GUI behavior: launching the GUI again focuses the existing window instead of opening a duplicate.\n- Add optional system tray support with show/restart/quit actions and autostart desktop entry during install.\n- Extend GUI config for auto model and STT provider.\n\n## Validation\n- `python3 -m py_compile whisper-dictation.py frontend_gui.py frontend_config.py frontend_service.py`\n- `python3 -m ruff check .`\n- `python3 -m pytest -q`\n- `bash -n install.sh`\n\nCloses #22